### PR TITLE
SSQP spec updates

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,11 @@
+# Table of Contents #
+
+[Simple Symbol Server Protocol (SSQP)](Simple_Symbol_Query_Protocol.md) - Describes the protocol used by clients to download files from a symbol server
+
+[Package Based Symbol Server](Package_Based_Symbol_Server.md) - Describes a particular subset of SSQP servers that use specially formatted .zip or nuget packages to represent the files that will be made available.
+
+[Myget symbol server feature request](Myget_symbol_server_extensions.md) - A feature request to the myget team to implement a Package Based Symbol Server
+
+[SSQP Key Conventions](SSQP_Key_Conventions.md) - A description of the standard key formats intended for use with SSQP.
+
+[CLR Private SSQP Key Conventions](SSQP_CLR_Private_Key_Conventions.md) - A description of non-standard key formats produced solely by the CLR team

--- a/docs/specs/SSQP_CLR_Private_Key_Conventions.md
+++ b/docs/specs/SSQP_CLR_Private_Key_Conventions.md
@@ -1,0 +1,47 @@
+# SSQP CLR Private Key conventions #
+
+These conventions are private extensions to the normal [SSQP conventions](SSQP_Key_Conventions.md). They fulfill niche scenarios specific to the CLR product and are not expected to be used within any general purpose index generating tool.
+
+## Basic rules ##
+
+The private conventions use the same basic rules for bytes, bytes sequences, integers, strings, etc as described in the standard conventions.
+
+## Key formats ##
+
+### PE-filesize-timestamp-coreclr
+
+This key indexes an sos\*.dll or mscordaccore\*.dll file that should be used to debug a given coreclr.dll. The lookup key is computed similar to PE-timestamp-filesize except the timestamp and filesize values are taken from coreclr.dll rather than the file being indexed.
+Example:
+
+**Filename:** mscordaccore.dll
+
+**CoreCLR’s COFF header Timestamp field:** 0x542d5742
+
+**CoreCLR’s COFF header SizeOfImage field:** 0x32000
+
+**Lookup key:** mscordaccore.dll/542d574200032000/mscordaccore.dll
+
+
+### ELF-buildid-coreclr
+
+This applies to any file named libmscordaccore.so or libsos.so that should be used to debug a given libcoreclr.so. The key is computed similarly to ELF-buildid except the note bytes is retrieved from the libcoreclr.so file and prepended with ‘elf-buildid-coreclr-‘.
+
+Example:
+
+**Filename:** libmscordaccore.so
+
+**Libcoreclr’s build note bytes:** 0x49, 0x7B, 0x72, 0xF6, 0x39, 0x0A, 0x44, 0xFC, 0x87, 0x8E
+
+**Lookup key:** mscordaccore.so/elf-buildid-coreclr-497b72f6390a44fc878e/mscordaccore.so
+
+### Mach-uuid-coreclr
+
+This applies to any file named libmscordaccore.dylib or libsos.dylib that should be used to debug a given libcoreclr.dylib. The key is computed similarly to Mach-uuid except the uuid is retrieved from the libcoreclr.dylib file and prepended with ‘mach-uuid-coreclr-‘
+
+Example:
+
+**Filename:** libmscordaccore.dylb
+
+**Coreclr’s uuid bytes:** 0x49, 0x7B, 0x72, 0xF6, 0x39, 0x0A, 0x44, 0xFC, 0x87, 0x8E, 0x5A, 0x2D, 0x63, 0xB6, 0xCC, 0x4B
+
+**Lookup key:** libmscordaccore.dylib/mach-uuid-coreclr-497b72f6390a44fc878e5a2d63b6cc4b/libmscordaccore.dylib

--- a/docs/specs/SSQP_Key_Conventions.md
+++ b/docs/specs/SSQP_Key_Conventions.md
@@ -1,0 +1,121 @@
+# SSQP Key conventions #
+
+When using [SSQP](Simple_Symbol_Server_Protocol) it is critical that the content publishers and content consumers agree what keys should correspond to which files. Although any publisher-consumer pair is free to create private agreements, using a standard key format offers the widest compatibility.
+
+
+## Key formatting basic rules
+Unless otherwise specified:
+
+- Bytes: Convert to characters by splitting the byte into the most significant 4 bits and 4 least significant bits, each of which has value 0-15. Convert each of those chunks to the corresponding lower case hexadecimal character. Last concatenate the two characters putting the most significant bit chunk first. For example 0 => '00', 1 => '01', 45 => '2d', 185 => 'b9'
+- Byte sequences: Convert to characters by converting each byte as above and then concatenating the characters. For example 2,45,4 => '022d04'
+- Multi-byte integers: Convert to characters by first converting it to a big-endian byte sequence next convert the sequence as above and finally trim all leading '0' characters. Example 3,559,453,162 => 'd428f1ea', 114 => '72'
+- strings: Convert all the characters to lower-case
+- guid: The guid consists of a 4 byte integer, two 2 byte integers, and a sequence of 8 bytes. It is formatted by converting each portion to hex characters without trimming leading '0' characters on the integers, then concatenate the results. Example: { 0x097B72F6, 0x390A, 0x04FC, { 0x87, 0x8E, 0x5A, 0x2D, 0x63, 0xB6, 0xCC, 0x4B } } => '097b72f6390a04fc878e5a2d63b6cc4b'
+
+## Key formats
+
+### PE-timestamp-filesize
+This key references Windows Portable Executable format files which commonly have .dll or .exe suffixes. The key is computed by extracting the Timestamp (4 byte integer) and SizeOfImage (4 byte integer) fields from the COFF header in PE image. The key is formatted <filename\>/<Timestamp\><SizeOfImage\>/<filename\>
+
+Example:
+	
+**Filename:** Foo.exe
+
+**COFF header Timestamp field:** 0x542d5742
+
+**COFF header SizeOfImage field:** 0x32000
+
+**Lookup key:** foo.exe/542d574200032000/foo.exe
+
+
+### PDB-Signature-Age
+
+This applies to Microsoft C++ Symbol Format, commonly called PDB and using files with the .pdb file extension. The key is computed by extracting the Signature (guid) and Age (4 byte integer) values from the guid stream within MSF container. The final key is formatted <filename\>/<Signature\><Age\>/<filename\>.
+
+Example:
+
+**Filename:** Foo.pdb
+
+**Signature field:** { 0x497B72F6, 0x390A, 0x44FC, { 0x87, 0x8E, 0x5A, 0x2D, 0x63, 0xB6, 0xCC, 0x4B } }
+
+**Age field:** 0x1
+
+**Lookup key**: foo.pdb/497b72f6390a44fc878e5a2d63b6cc4b1/foo.pdb
+
+
+###Portable-Pdb-Signature
+
+This applies to Microsoft .Net portable PDB format files, commonly using the suffix .pdb. The key is computed by extracting the Signature (guid) from debug metadata header. The final key is formatted: <filename\>/ppdb-sig-<guid\>/<filename\>.
+ 
+Example:
+	
+**Filename:** Foo.pdb
+
+**Signature field:** { 0x497B72F6, 0x390A, 0x44FC { 0x87, 0x8E, 0x5A, 0x2D, 0x63, 0xB6, 0xCC, 0x4B } }
+
+**Lookup key:** foo.pdb/ppdb-sig-497b72f6390a44fc878e5a2d63b6cc4b/foo.pdb
+
+
+### ELF-buildid
+
+This applies to any ELF format files that have been stripped of debugging information, commonly using the .so suffix or no suffix. The key is computed by reading the byte sequence of the ELF Note section that is named “GNU” and that has note type PRPSINFO (3). The final key is formatted: <filename\>/elf-buildid-<note_byte_sequence\>/<filename\>.
+
+Example:
+	
+**Filename:** Foo.so
+
+**Build note bytes:** 0x49, 0x7B, 0x72, 0xF6, 0x39, 0x0A, 0x44, 0xFC, 0x87, 0x8E
+
+**Lookup key:** foo.so/elf-buildid-497b72f6390a44fc878e/foo.so
+
+
+###ELF-buildid-sym
+
+This applies to any ELF format files that have not been stripped of debugging information, commonly ending in ‘.so.dbg’ or ‘.dbg’. The key is computed by reading the byte sequence of the ELF Note section that is named “GNU” and that has note type PRPSINFO (3). The final key is formatted:
+<filename\>/elf-buildid-sym-<note\_byte\_sequence\>/<filename\>.
+
+Example:
+
+**Filename:** Foo.so.dbg
+
+**Build note bytes:** 0x49, 0x7B, 0x72, 0xF6, 0x39, 0x0A, 0x44, 0xFC, 0x87, 0x8E
+
+**Lookup key:** foo.so.dbg/elf-buildid-sym-497b72f6390a44fc878e/foo.so.dbg
+
+
+### Mach-uuid
+This applies to any MachO format files that have been stripped of debugging information, commonly ending in 'dylib'. The key is computed by reading the uuid byte sequence of the MachO LC_UUID load command. The final key is formatted <filename\>/mach-uuid-<uuid\_bytes\>/<filename\>
+
+Example:
+
+**Filename:** Foo.dylb
+
+**Uuid bytes:** 0x49, 0x7B, 0x72, 0xF6, 0x39, 0x0A, 0x44, 0xFC, 0x87, 0x8E, 0x5A, 0x2D, 0x63, 0xB6, 0xCC, 0x4B
+
+**Lookup key:** foo.dylib/mach-uuid-497b72f6390a44fc878e5a2d63b6cc4b/foo.dylib
+
+
+###Mach-uuid-sym
+
+This applies to any MachO format files that have not been stripped of debugging information, commonly ending in '.dylib.dwarf'. The key is computed by reading the uuid byte sequence of the MachO LC_UUID load command. The final key is formatted <filename\>/mach-uuid-sym-<uuid\_bytes\>/<filename\>
+
+Example:
+
+**Filename:** Foo.dylb
+
+**Uuid bytes:** 0x49, 0x7B, 0x72, 0xF6, 0x39, 0x0A, 0x44, 0xFC, 0x87, 0x8E, 0x5A, 0x2D, 0x63, 0xB6, 0xCC, 0x4B
+
+**Lookup key:** foo.dylib/mach-uuid-sym-497b72f6390a44fc878e5a2d63b6cc4b/foo.dylib
+
+
+### SHA1
+
+This applies to any file, but is commonly used on sources. The key is computed by calculating a SHA1 hash, then formatting the 20 byte hash sequence prepended with “sha1-“
+
+Example:
+
+**Filename:** Foo.cs
+
+**Sha1 hash bytes:** 0x49, 0x7B, 0x72, 0xF6, 0x39, 0x0A, 0x44, 0xFC, 0x87, 0x8E, 0x5A, 0x2D, 0x63, 0xB6, 0xCC, 0x4B, 0x0C, 0x2D, 0x99, 0x84
+
+**Lookup key:** foo.cs/sha1-497b72f6390a44fc878e5a2d63b6cc4b0c2d9984/foo.cs

--- a/docs/specs/Simple_Symbol_Query_Protocol.md
+++ b/docs/specs/Simple_Symbol_Query_Protocol.md
@@ -5,7 +5,7 @@ Frequently when diagnosing computer programs there is a need to retrieve additio
 The protocol solely consists of a mechanism for the client to provide a key, the 'clientKey', identifying the file it wants. The server then sends back that file. The publisher that created the content and client that downloads it may understand the semantics of the key and the resulting file, but from the perspective of the protocol and the server these items are merely character sequences and binary blobs. 
 
 ## Request ##
-All requests are [HTTP/1.1](https://tools.ietf.org/html/rfc2616 "HTTP/1.1") messages using the 'get' verb. The client is configured with a valid URI for the service endpoint, and a clientKey it wants to retrieve. The client should request URI <service_endpoint\>/<clientKey\>. 
+All requests are [HTTP/1.1](https://tools.ietf.org/html/rfc2616 "HTTP/1.1") messages using the 'get' verb. The client is configured with a valid URI for the service endpoint, and a clientKey it wants to retrieve. The client should request URI <service\_endpoint\>/<encodedClientKey\>. 
 
  For example:
 
@@ -13,11 +13,10 @@ All requests are [HTTP/1.1](https://tools.ietf.org/html/rfc2616 "HTTP/1.1") mess
 
 **clientKey:** debug\_info.txt/12345abcdefg/debug\_info.txt
 
-
-    GET http://www.contuso.com/symbol/server/debug_info.txt/12345abcdefg/debug_info.txt
+    GET http://www.contuso.com/symbol/server/debug\_info.txt/12345abcdefg/debug\_info.txt
 
 ### Encoding and case sensitivity ###
-The clientKey needs to be URL encoded as it may contain characters outside the [URI unreserved character set](https://tools.ietf.org/html/rfc3986#Section-2.3). clientKey is not case-sensitive. Clients are encouraged to normalize to lower-case in the request URI, but the server should perform any clientKey comparisons in a case-insensitive manner regardless.
+The clientKey needs to be URL encoded as it may contain characters outside the [URI unreserved character set](https://tools.ietf.org/html/rfc3986#Section-2.3). Any '/' character should not be escaped, but all other characters are URL encoded as normal. clientKey is not case-sensitive. Clients are encouraged to normalize the encoding to lower-case in the request URI, but the server should perform any clientKey comparisons in a case-insensitive manner regardless.
 
 ## Response ##
 
@@ -27,7 +26,7 @@ An http 304 redirection will be honored by the client.
 
 ## Relation to the SymSrv protocol ##
 
-This protocol has been deliberately designed so that when used with the [recommended key conventions](todo) for windows file types it is also compatible with windows SymSrv clients.
+This protocol has been deliberately designed so that when used with the [recommended key conventions](SSQP_Key_Conventions.md) for windows file types it is also compatible with windows SymSrv clients.
 
 ## Security Warnings ##
 ### ClientKeys ###
@@ -36,10 +35,10 @@ Be careful about assuming that client keys can be interpreted as relative file s
 ### Trusting downloaded files ###
 Clients consuming the diagnostic files downloaded via SSQP often expect that there is a certain relationship between the key and the data that is downloaded. For example a client may expect requesting key 'sha-1-123878123871238712378519847' guarantees that the data which comes back has the given hash. The server is not required to do any verification of this however. A client that wants to be certain must either:
 
- - verify this is the case after the data has been downloaded
+ - verify that invariants hold after the data has been downloaded
  - trust the author of the mapping data, every intermediary that handled the data at rest or in transit, and know that none of the trusted parties merge in any clientKey mappings from untrusted parties
 
-There are internet hosted symbol server implementations that DO merge mappings from untrusted and potentially anonymous 3rd parties. In this case it is trivial for an attacker to pose as such a 3rd party and add mappings that remap legitimate clientKeys to arbitrary attacker chosen files. Clients need to assume that ANY data returned by such a service could have been tampered with, regardless of whether the particular key being requested was derived from a trusted source. 
+There are internet hosted symbol server implementations that DO merge mappings from untrusted and potentially anonymous 3rd parties. In this case it is trivial for an attacker to pose as such a 3rd party and add mappings that remap legitimate clientKeys to arbitrary attacker chosen files. Clients need to assume that ANY data returned by such a service could have been tampered with, regardless of whether the particular key being requested was originally derived from a trusted source. 
 
 For tools that allow the end-user to specify the SSQP endpoint to connect to, consider the risk that the end-user may change configuration from a service that hosts only trusted content to a service  that hosts untrusted content without realizing the security implications of this choice. Some guides on the web from reputable and independent sources explicitly tell developers to make such configuration changes without any mention of the risks.
 


### PR DESCRIPTION
Add docs describing clientKey formats
Add a README to index all the docs
Clarify handling of the '/' character inside SSQP client keys when encoded in URIs and made other minor updates