### PR TITLE
Restoring the xproj build

### DIFF
--- a/SymStore.sln
+++ b/SymStore.sln
@@ -13,23 +13,13 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.SymbolStore.Clien
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FileFormats", "src\FileFormats\FileFormats.csproj", "{256F3AFA-B659-44B0-BC6F-3C9912E9DD4F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FileFormats.Tests", "src\FileFormats.Tests\FileFormats.Tests.csproj", "{478E394E-C5B1-4FFD-A1E8-A8C1BA0A5E08}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FileFormats.PE", "src\FileFormats.PE\FileFormats.PE.csproj", "{455E157D-E0F0-4C1F-9073-CBC8B0BC1537}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FileFormats.PE.Tests", "src\FileFormats.PE.Tests\FileFormats.PE.Tests.csproj", "{DBFB6381-155B-4C1F-BC26-AA8ACF24D216}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FileFormats.PDB", "src\FileFormats.PDB\FileFormats.PDB.csproj", "{5B0BA4E9-FD55-4507-BCCB-B03AAE4CF179}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FileFormats.PDB.Tests", "src\FileFormats.PDB.Tests\FileFormats.PDB.Tests.csproj", "{8B48F5B6-40E2-4728-A73D-F2D542A2A2FD}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FileFormats.ELF", "src\FileFormats.ELF\FileFormats.ELF.csproj", "{2F8BA26C-DA53-45CB-A122-F96C654078D8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FileFormats.ELF.Tests", "src\FileFormats.ELF.Tests\FileFormats.ELF.Tests.csproj", "{C769642F-B7E2-488B-BC10-B14E411F9EAD}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FileFormats.MachO", "src\FileFormats.MachO\FileFormats.MachO.csproj", "{06D60FC0-FF3C-4713-A19D-A8F0D3682972}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FileFormats.MachO.Tests", "src\FileFormats.MachO.Tests\FileFormats.MachO.Tests.csproj", "{2CD8523F-9C6E-4193-A628-CB9912E47F9B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -79,14 +69,6 @@ Global
 		{256F3AFA-B659-44B0-BC6F-3C9912E9DD4F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{256F3AFA-B659-44B0-BC6F-3C9912E9DD4F}.Release|x64.ActiveCfg = Release|Any CPU
 		{256F3AFA-B659-44B0-BC6F-3C9912E9DD4F}.Release|x64.Build.0 = Release|Any CPU
-		{478E394E-C5B1-4FFD-A1E8-A8C1BA0A5E08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{478E394E-C5B1-4FFD-A1E8-A8C1BA0A5E08}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{478E394E-C5B1-4FFD-A1E8-A8C1BA0A5E08}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{478E394E-C5B1-4FFD-A1E8-A8C1BA0A5E08}.Debug|x64.Build.0 = Debug|Any CPU
-		{478E394E-C5B1-4FFD-A1E8-A8C1BA0A5E08}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{478E394E-C5B1-4FFD-A1E8-A8C1BA0A5E08}.Release|Any CPU.Build.0 = Release|Any CPU
-		{478E394E-C5B1-4FFD-A1E8-A8C1BA0A5E08}.Release|x64.ActiveCfg = Release|Any CPU
-		{478E394E-C5B1-4FFD-A1E8-A8C1BA0A5E08}.Release|x64.Build.0 = Release|Any CPU
 		{455E157D-E0F0-4C1F-9073-CBC8B0BC1537}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{455E157D-E0F0-4C1F-9073-CBC8B0BC1537}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{455E157D-E0F0-4C1F-9073-CBC8B0BC1537}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -95,14 +77,6 @@ Global
 		{455E157D-E0F0-4C1F-9073-CBC8B0BC1537}.Release|Any CPU.Build.0 = Release|Any CPU
 		{455E157D-E0F0-4C1F-9073-CBC8B0BC1537}.Release|x64.ActiveCfg = Release|Any CPU
 		{455E157D-E0F0-4C1F-9073-CBC8B0BC1537}.Release|x64.Build.0 = Release|Any CPU
-		{DBFB6381-155B-4C1F-BC26-AA8ACF24D216}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{DBFB6381-155B-4C1F-BC26-AA8ACF24D216}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{DBFB6381-155B-4C1F-BC26-AA8ACF24D216}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{DBFB6381-155B-4C1F-BC26-AA8ACF24D216}.Debug|x64.Build.0 = Debug|Any CPU
-		{DBFB6381-155B-4C1F-BC26-AA8ACF24D216}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{DBFB6381-155B-4C1F-BC26-AA8ACF24D216}.Release|Any CPU.Build.0 = Release|Any CPU
-		{DBFB6381-155B-4C1F-BC26-AA8ACF24D216}.Release|x64.ActiveCfg = Release|Any CPU
-		{DBFB6381-155B-4C1F-BC26-AA8ACF24D216}.Release|x64.Build.0 = Release|Any CPU
 		{5B0BA4E9-FD55-4507-BCCB-B03AAE4CF179}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5B0BA4E9-FD55-4507-BCCB-B03AAE4CF179}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5B0BA4E9-FD55-4507-BCCB-B03AAE4CF179}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -111,14 +85,6 @@ Global
 		{5B0BA4E9-FD55-4507-BCCB-B03AAE4CF179}.Release|Any CPU.Build.0 = Release|Any CPU
 		{5B0BA4E9-FD55-4507-BCCB-B03AAE4CF179}.Release|x64.ActiveCfg = Release|Any CPU
 		{5B0BA4E9-FD55-4507-BCCB-B03AAE4CF179}.Release|x64.Build.0 = Release|Any CPU
-		{8B48F5B6-40E2-4728-A73D-F2D542A2A2FD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{8B48F5B6-40E2-4728-A73D-F2D542A2A2FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{8B48F5B6-40E2-4728-A73D-F2D542A2A2FD}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{8B48F5B6-40E2-4728-A73D-F2D542A2A2FD}.Debug|x64.Build.0 = Debug|Any CPU
-		{8B48F5B6-40E2-4728-A73D-F2D542A2A2FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{8B48F5B6-40E2-4728-A73D-F2D542A2A2FD}.Release|Any CPU.Build.0 = Release|Any CPU
-		{8B48F5B6-40E2-4728-A73D-F2D542A2A2FD}.Release|x64.ActiveCfg = Release|Any CPU
-		{8B48F5B6-40E2-4728-A73D-F2D542A2A2FD}.Release|x64.Build.0 = Release|Any CPU
 		{2F8BA26C-DA53-45CB-A122-F96C654078D8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2F8BA26C-DA53-45CB-A122-F96C654078D8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2F8BA26C-DA53-45CB-A122-F96C654078D8}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -127,14 +93,6 @@ Global
 		{2F8BA26C-DA53-45CB-A122-F96C654078D8}.Release|Any CPU.Build.0 = Release|Any CPU
 		{2F8BA26C-DA53-45CB-A122-F96C654078D8}.Release|x64.ActiveCfg = Release|Any CPU
 		{2F8BA26C-DA53-45CB-A122-F96C654078D8}.Release|x64.Build.0 = Release|Any CPU
-		{C769642F-B7E2-488B-BC10-B14E411F9EAD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C769642F-B7E2-488B-BC10-B14E411F9EAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C769642F-B7E2-488B-BC10-B14E411F9EAD}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{C769642F-B7E2-488B-BC10-B14E411F9EAD}.Debug|x64.Build.0 = Debug|Any CPU
-		{C769642F-B7E2-488B-BC10-B14E411F9EAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C769642F-B7E2-488B-BC10-B14E411F9EAD}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C769642F-B7E2-488B-BC10-B14E411F9EAD}.Release|x64.ActiveCfg = Release|Any CPU
-		{C769642F-B7E2-488B-BC10-B14E411F9EAD}.Release|x64.Build.0 = Release|Any CPU
 		{06D60FC0-FF3C-4713-A19D-A8F0D3682972}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{06D60FC0-FF3C-4713-A19D-A8F0D3682972}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{06D60FC0-FF3C-4713-A19D-A8F0D3682972}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -143,14 +101,6 @@ Global
 		{06D60FC0-FF3C-4713-A19D-A8F0D3682972}.Release|Any CPU.Build.0 = Release|Any CPU
 		{06D60FC0-FF3C-4713-A19D-A8F0D3682972}.Release|x64.ActiveCfg = Release|Any CPU
 		{06D60FC0-FF3C-4713-A19D-A8F0D3682972}.Release|x64.Build.0 = Release|Any CPU
-		{2CD8523F-9C6E-4193-A628-CB9912E47F9B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2CD8523F-9C6E-4193-A628-CB9912E47F9B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2CD8523F-9C6E-4193-A628-CB9912E47F9B}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{2CD8523F-9C6E-4193-A628-CB9912E47F9B}.Debug|x64.Build.0 = Debug|Any CPU
-		{2CD8523F-9C6E-4193-A628-CB9912E47F9B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2CD8523F-9C6E-4193-A628-CB9912E47F9B}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2CD8523F-9C6E-4193-A628-CB9912E47F9B}.Release|x64.ActiveCfg = Release|Any CPU
-		{2CD8523F-9C6E-4193-A628-CB9912E47F9B}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SymStore_dotnet.sln
+++ b/SymStore_dotnet.sln
@@ -1,0 +1,94 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "DownloadDumpFiles", "src\DownloadDumpFiles\DownloadDumpFiles.xproj", "{087FA673-8FA2-42C3-827E-7616B5087285}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "FileFormats", "src\FileFormats\FileFormats.xproj", "{F1213DA6-9EB9-4F33-9183-6BFD49412D19}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "FileFormats.ELF", "src\FileFormats.ELF\FileFormats.ELF.xproj", "{ABB8D17D-FB16-4B5A-BFBE-CAB2100B8650}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "FileFormats.MachO", "src\FileFormats.MachO\FileFormats.MachO.xproj", "{4FDE26C9-B5C7-4710-899E-87D3D7293723}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NugetSymbolServer", "src\NugetSymbolServer\NugetSymbolServer.xproj", "{205B3776-FF36-4349-AEE5-1CD8EE8FB881}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "FileFormats.PDB", "src\FileFormats.PDB\FileFormats.PDB.xproj", "{57689F99-AF05-4779-A5A0-03695BFEF08E}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "EmbedIndex", "src\EmbedIndex\EmbedIndex.xproj", "{4E7A01B0-57CE-4A96-9500-D6C8566E6483}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "FileFormats.PE", "src\FileFormats.PE\FileFormats.PE.xproj", "{B2024114-26CB-4BC0-A363-36746B7911B1}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "FileFormats.ELF.Tests", "src\FileFormats.ELF.Tests\FileFormats.ELF.Tests.xproj", "{D700D39E-1862-4B28-8D97-95C92DC735B5}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "FileFormats.MachO.Tests", "src\FileFormats.MachO.Tests\FileFormats.MachO.Tests.xproj", "{B7CEA652-AD2C-46E2-8F2C-0FDC617233A2}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "FileFormats.PDB.Tests", "src\FileFormats.PDB.Tests\FileFormats.PDB.Tests.xproj", "{818E05AB-FA8F-4D6F-A2D5-AD5851632CAC}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "FileFormats.Tests", "src\FileFormats.Tests\FileFormats.Tests.xproj", "{2177FA4A-3A4E-408D-8F13-A184C3050F46}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "FileFormats.PE.Tests", "src\FileFormats.PE.Tests\FileFormats.PE.Tests.xproj", "{618AE198-9422-4076-9289-DB26DFF4882D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{087FA673-8FA2-42C3-827E-7616B5087285}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{087FA673-8FA2-42C3-827E-7616B5087285}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{087FA673-8FA2-42C3-827E-7616B5087285}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{087FA673-8FA2-42C3-827E-7616B5087285}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F1213DA6-9EB9-4F33-9183-6BFD49412D19}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F1213DA6-9EB9-4F33-9183-6BFD49412D19}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F1213DA6-9EB9-4F33-9183-6BFD49412D19}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F1213DA6-9EB9-4F33-9183-6BFD49412D19}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ABB8D17D-FB16-4B5A-BFBE-CAB2100B8650}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ABB8D17D-FB16-4B5A-BFBE-CAB2100B8650}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ABB8D17D-FB16-4B5A-BFBE-CAB2100B8650}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ABB8D17D-FB16-4B5A-BFBE-CAB2100B8650}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4FDE26C9-B5C7-4710-899E-87D3D7293723}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4FDE26C9-B5C7-4710-899E-87D3D7293723}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4FDE26C9-B5C7-4710-899E-87D3D7293723}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4FDE26C9-B5C7-4710-899E-87D3D7293723}.Release|Any CPU.Build.0 = Release|Any CPU
+		{205B3776-FF36-4349-AEE5-1CD8EE8FB881}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{205B3776-FF36-4349-AEE5-1CD8EE8FB881}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{205B3776-FF36-4349-AEE5-1CD8EE8FB881}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{205B3776-FF36-4349-AEE5-1CD8EE8FB881}.Release|Any CPU.Build.0 = Release|Any CPU
+		{57689F99-AF05-4779-A5A0-03695BFEF08E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{57689F99-AF05-4779-A5A0-03695BFEF08E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{57689F99-AF05-4779-A5A0-03695BFEF08E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{57689F99-AF05-4779-A5A0-03695BFEF08E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E7A01B0-57CE-4A96-9500-D6C8566E6483}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E7A01B0-57CE-4A96-9500-D6C8566E6483}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E7A01B0-57CE-4A96-9500-D6C8566E6483}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E7A01B0-57CE-4A96-9500-D6C8566E6483}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2024114-26CB-4BC0-A363-36746B7911B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2024114-26CB-4BC0-A363-36746B7911B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2024114-26CB-4BC0-A363-36746B7911B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2024114-26CB-4BC0-A363-36746B7911B1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D700D39E-1862-4B28-8D97-95C92DC735B5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D700D39E-1862-4B28-8D97-95C92DC735B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D700D39E-1862-4B28-8D97-95C92DC735B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D700D39E-1862-4B28-8D97-95C92DC735B5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B7CEA652-AD2C-46E2-8F2C-0FDC617233A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B7CEA652-AD2C-46E2-8F2C-0FDC617233A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B7CEA652-AD2C-46E2-8F2C-0FDC617233A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B7CEA652-AD2C-46E2-8F2C-0FDC617233A2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{818E05AB-FA8F-4D6F-A2D5-AD5851632CAC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{818E05AB-FA8F-4D6F-A2D5-AD5851632CAC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{818E05AB-FA8F-4D6F-A2D5-AD5851632CAC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{818E05AB-FA8F-4D6F-A2D5-AD5851632CAC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2177FA4A-3A4E-408D-8F13-A184C3050F46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2177FA4A-3A4E-408D-8F13-A184C3050F46}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2177FA4A-3A4E-408D-8F13-A184C3050F46}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2177FA4A-3A4E-408D-8F13-A184C3050F46}.Release|Any CPU.Build.0 = Release|Any CPU
+		{618AE198-9422-4076-9289-DB26DFF4882D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{618AE198-9422-4076-9289-DB26DFF4882D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{618AE198-9422-4076-9289-DB26DFF4882D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{618AE198-9422-4076-9289-DB26DFF4882D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/DownloadDumpFiles/DownloadDumpFiles.xproj
+++ b/src/DownloadDumpFiles/DownloadDumpFiles.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>087fa673-8fa2-42c3-827e-7616b5087285</ProjectGuid>
+    <RootNamespace>DownloadDumpFiles</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/EmbedIndex/EmbedIndex.xproj
+++ b/src/EmbedIndex/EmbedIndex.xproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>4e7a01b0-57ce-4a96-9500-d6c8566e6483</ProjectGuid>
+    <RootNamespace>DownloadDumpFiles</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/FileFormats.ELF.Tests/FileFormats.ELF.Tests.xproj
+++ b/src/FileFormats.ELF.Tests/FileFormats.ELF.Tests.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>d700d39e-1862-4b28-8d97-95c92dc735b5</ProjectGuid>
+    <RootNamespace>DownloadDumpFiles</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/FileFormats.ELF.Tests/project.json
+++ b/src/FileFormats.ELF.Tests/project.json
@@ -1,15 +1,21 @@
 {
+  "version": "1.0.0-*",
+  "testRunner": "xunit",
   "dependencies": {
-    "FileFormats": "1.0.0",
-    "FileFormats.ELF": "1.0.0",
-    "NETStandard.Library": "1.6.0",
-    "xunit": "2.1.0",
-    "xunit.runner.console": "2.1.0",
-    "xunit.runner.visualstudio": "2.1.0"
+    "xunit": "2.2.0-beta2-build3300",
+    "FileFormats.ELF": "1.0.0-*",
+    "FileFormats": "1.0.0-*",
+    "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "frameworks": {
-    "netstandard1.5": {
-      "imports": [ "portable-net452", "dotnet5.4" ]
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
+      }
     }
   }
 }
+

--- a/src/FileFormats.ELF/FileFormats.ELF.xproj
+++ b/src/FileFormats.ELF/FileFormats.ELF.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>abb8d17d-fb16-4b5a-bfbe-cab2100b8650</ProjectGuid>
+    <RootNamespace>FileFormats.ELF</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/FileFormats.MachO.Tests/FileFormats.MachO.Tests.xproj
+++ b/src/FileFormats.MachO.Tests/FileFormats.MachO.Tests.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>b7cea652-ad2c-46e2-8f2c-0fdc617233a2</ProjectGuid>
+    <RootNamespace>DownloadDumpFiles</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/FileFormats.MachO.Tests/project.json
+++ b/src/FileFormats.MachO.Tests/project.json
@@ -1,15 +1,20 @@
 {
+  "version": "1.0.0-*",
+  "testRunner": "xunit",
   "dependencies": {
-    "FileFormats": "1.0.0",
-    "FileFormats.MachO": "1.0.0",
-    "NETStandard.Library": "1.6.0",
-    "xunit": "2.1.0",
-    "xunit.runner.console": "2.1.0",
-    "xunit.runner.visualstudio": "2.1.0"
+    "xunit": "2.2.0-beta2-build3300",
+    "FileFormats.MachO": "1.0.0-*",
+    "FileFormats": "1.0.0-*",
+    "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "frameworks": {
-    "netstandard1.5": {
-      "imports": [ "portable-net452", "dotnet5.4" ]
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
+      }
     }
   }
 }

--- a/src/FileFormats.MachO/FileFormats.MachO.xproj
+++ b/src/FileFormats.MachO/FileFormats.MachO.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>4fde26c9-b5c7-4710-899e-87d3d7293723</ProjectGuid>
+    <RootNamespace>FileFormats.MachO</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/FileFormats.PDB.Tests/FileFormats.PDB.Tests.xproj
+++ b/src/FileFormats.PDB.Tests/FileFormats.PDB.Tests.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>818e05ab-fa8f-4d6f-a2d5-ad5851632cac</ProjectGuid>
+    <RootNamespace>DownloadDumpFiles</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/FileFormats.PDB.Tests/project.json
+++ b/src/FileFormats.PDB.Tests/project.json
@@ -1,15 +1,21 @@
 ﻿{
+  "version": "1.0.0-*",
+  "testRunner": "xunit",
   "dependencies": {
-    "FileFormats": "1.0.0",
-    "FileFormats.PDB": "1.0.0",
-    "NETStandard.Library": "1.6.0",
-    "xunit": "2.1.0",
-    "xunit.runner.console": "2.1.0",
-    "xunit.runner.visualstudio": "2.1.0"
+    "xunit": "2.2.0-beta2-build3300",
+    "FileFormats.PDB": "1.0.0-*",
+    "FileFormats": "1.0.0-*",
+    "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "frameworks": {
-    "netstandard1.5": {
-      "imports": [ "portable-net452", "dotnet5.4" ]
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
+      }
     }
   }
 }
+

--- a/src/FileFormats.PDB/FileFormats.PDB.xproj
+++ b/src/FileFormats.PDB/FileFormats.PDB.xproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>57689f99-af05-4779-a5a0-03695bfef08e</ProjectGuid>
+    <RootNamespace>DownloadDumpFiles</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/FileFormats.PE.Tests/FileFormats.PE.Tests.xproj
+++ b/src/FileFormats.PE.Tests/FileFormats.PE.Tests.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>618ae198-9422-4076-9289-db26dff4882d</ProjectGuid>
+    <RootNamespace>DownloadDumpFiles</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/FileFormats.PE.Tests/project.json
+++ b/src/FileFormats.PE.Tests/project.json
@@ -1,15 +1,20 @@
 ﻿{
+  "version": "1.0.0-*",
+  "testRunner": "xunit",
   "dependencies": {
-    "FileFormats": "1.0.0",
-    "FileFormats.PE": "1.0.0",
-    "NETStandard.Library": "1.6.0",
-    "xunit": "2.1.0",
-    "xunit.runner.console": "2.1.0",
-    "xunit.runner.visualstudio": "2.1.0"
+    "xunit": "2.2.0-beta2-build3300",
+    "FileFormats.PE": "1.0.0-*",
+    "FileFormats": "1.0.0-*",
+    "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "frameworks": {
-    "netstandard1.5": {
-      "imports": [ "portable-net452", "dotnet5.4" ]
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
+      }
     }
   }
 }

--- a/src/FileFormats.PE/FileFormats.PE.xproj
+++ b/src/FileFormats.PE/FileFormats.PE.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>b2024114-26cb-4bc0-a363-36746b7911b1</ProjectGuid>
+    <RootNamespace>FileFormats.PE</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/FileFormats.Tests/FileFormats.Tests.xproj
+++ b/src/FileFormats.Tests/FileFormats.Tests.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>2177fa4a-3a4e-408d-8f13-a184c3050f46</ProjectGuid>
+    <RootNamespace>DownloadDumpFiles</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/FileFormats.Tests/project.json
+++ b/src/FileFormats.Tests/project.json
@@ -1,13 +1,19 @@
 ﻿{
+  "version": "1.0.0-*",
+  "testRunner": "xunit",
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
-    "xunit": "2.1.0",
-    "xunit.runner.console": "2.1.0",
-    "xunit.runner.visualstudio": "2.1.0"
+    "xunit": "2.2.0-beta2-build3300",
+    "FileFormats": "1.0.0-*",
+    "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "frameworks": {
-    "netstandard1.5": {
-      "imports": [ "portable-net452" ]
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
+      }
     }
   }
 }

--- a/src/FileFormats/FileFormats.xproj
+++ b/src/FileFormats/FileFormats.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>f1213da6-9eb9-4f33-9183-6bfd49412d19</ProjectGuid>
+    <RootNamespace>FileFormats</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>


### PR DESCRIPTION
The build system in this repo has been problematic to work with ; ) I made SymStore_dotnet.sln as an alternate option that is more useful for local development right now.

I have tried getting the test projects to run following the pattern of the existing unit tests but I have not been successful. FileFormats needs a netstandard 1.5 dependency to build and then the test projects need the same dependency. Once I do that I can no longer follow the existing template exactly, though its unclear if this is really the source of the problem. Ultimately the tests do not show up in the VS test window which is awkward for development. However to get the tests working properly in the xproj based projects I needed to reference netcoreapp instead of netstandard 1.5, and that breaks the build from the .csproj build system. I removed the test projects from SymStore.sln so that CI doesn't break.

For the console apps I tried using a non-portable console app template, but trying to reference to ..\..\build\Targets\Imports.targets to match the other projects immediately broke the build. It seemed that if projects were going to use different sets of rules I may as well stay consistent and use the .xproj/dotnet scheme rather than introducing a 3rd variation.

I can easily imagine there is a better, more consistent solution, but it will take more time or someone more knowledgeable in this area to find it.