### PR TITLE
Update portable PDB indexing scheme and fix formatting

### DIFF
--- a/docs/specs/SSQP_Key_Conventions.md
+++ b/docs/specs/SSQP_Key_Conventions.md
@@ -43,9 +43,9 @@ Example:
 **Lookup key**: foo.pdb/497b72f6390a44fc878e5a2d63b6cc4b1/foo.pdb
 
 
-###Portable-Pdb-Signature
+### Portable-Pdb-Signature
 
-This applies to Microsoft .Net portable PDB format files, commonly using the suffix .pdb. The key is computed by extracting the Signature (guid) from debug metadata header. The final key is formatted: <filename\>/ppdb-sig-<guid\>/<filename\>.
+This applies to Microsoft .Net portable PDB format files, commonly using the suffix .pdb. The Portable PDB format uses the same key format as Windows PDBs, except that 0xffffffff (UInt32.MaxValue) is used for the age. In other words, the key is computed by extracting the Signature (guid) from debug metadata header and combining it with 'ffffffff'. The final key is formatted: <filename\>/<guid\>ffffffff/<filename\>.
  
 Example:
 	
@@ -53,7 +53,7 @@ Example:
 
 **Signature field:** { 0x497B72F6, 0x390A, 0x44FC { 0x87, 0x8E, 0x5A, 0x2D, 0x63, 0xB6, 0xCC, 0x4B } }
 
-**Lookup key:** foo.pdb/ppdb-sig-497b72f6390a44fc878e5a2d63b6cc4b/foo.pdb
+**Lookup key:** foo.pdb/497b72f6390a44fc878e5a2d63b6cc4bffffffff/foo.pdb
 
 
 ### ELF-buildid
@@ -69,7 +69,7 @@ Example:
 **Lookup key:** foo.so/elf-buildid-497b72f6390a44fc878e/foo.so
 
 
-###ELF-buildid-sym
+### ELF-buildid-sym
 
 This applies to any ELF format files that have not been stripped of debugging information, commonly ending in ‘.so.dbg’ or ‘.dbg’. The key is computed by reading the byte sequence of the ELF Note section that is named “GNU” and that has note type PRPSINFO (3). The final key is formatted:
 <filename\>/elf-buildid-sym-<note\_byte\_sequence\>/<filename\>.
@@ -95,7 +95,7 @@ Example:
 **Lookup key:** foo.dylib/mach-uuid-497b72f6390a44fc878e5a2d63b6cc4b/foo.dylib
 
 
-###Mach-uuid-sym
+### Mach-uuid-sym
 
 This applies to any MachO format files that have not been stripped of debugging information, commonly ending in '.dylib.dwarf'. The key is computed by reading the uuid byte sequence of the MachO LC_UUID load command. The final key is formatted <filename\>/mach-uuid-sym-<uuid\_bytes\>/<filename\>
 

--- a/src/EmbedIndex/README.md
+++ b/src/EmbedIndex/README.md
@@ -4,7 +4,7 @@ This is a proof of concept implementation of creating a nuget package which cont
   
 ## Running the example ##
 
-###Create a hello world nuget package that we can use as input ###
+### Create a hello world nuget package that we can use as input ###
 
 Follow the directions to make a HelloWorld sample here: https://www.microsoft.com/net/core. After the sample runs use 'nuget pack' to create a nuget package
 

--- a/src/Microsoft.SymbolStore.Client/StoreQueryBuilder.cs
+++ b/src/Microsoft.SymbolStore.Client/StoreQueryBuilder.cs
@@ -6,8 +6,7 @@ namespace Microsoft.SymbolStore
 {
     internal static class StoreQueryBuilder
     {
-        public static readonly string PortablePdbPrefix = "ppdb-sig-";
-        public static readonly string WindowsPdbPrefix = "";
+        public static readonly string PdbPrefix = "";
 
         public static readonly string ElfImagePrefix = "elf-buildid-";
         public static readonly string ElfSymbolPrefix = "elf-buildid-sym-";
@@ -17,14 +16,14 @@ namespace Microsoft.SymbolStore
 
         public static readonly string SourcePrefix = "sha1";
 
-        public static string GetPortablePdbQueryString(Guid guid, uint stamp, string fileName)
+        public static string GetPortablePdbQueryString(Guid guid, string fileName)
         {
-            return fileName + "/" + PortablePdbPrefix + guid.ToString("N") + stamp.ToString("x8") + "/" + fileName;
+            return fileName + "/" + PdbPrefix + guid.ToString("N") + "ffffffff" + "/" + fileName;
         }
 
         public static string GetWindowsPdbQueryString(Guid guid, int age, string fileName)
         {
-            return fileName + "/" + WindowsPdbPrefix + guid.ToString("N") + age.ToString() + "/" + fileName;
+            return fileName + "/" + PdbPrefix + guid.ToString("N") + age.ToString() + "/" + fileName;
         }
     }
 }

--- a/src/Microsoft.SymbolStore.Client/SymbolStoreClient.cs
+++ b/src/Microsoft.SymbolStore.Client/SymbolStoreClient.cs
@@ -46,7 +46,7 @@ namespace Microsoft.SymbolStore
             StoreUri = storeUri;
         }
 
-        public async Task<Stream> GetSymbolFileForPortableExecutable(int version, Guid guid, uint stamp, int age, string fileName, bool portableOnly)
+        public async Task<Stream> GetSymbolFileForPortableExecutable(int version, Guid guid, int age, string fileName, bool portableOnly)
         {
             if (fileName == null)
             {
@@ -64,7 +64,7 @@ namespace Microsoft.SymbolStore
             string query;
             if (hasPortablePdb || portableOnly)
             {
-                query = StoreQueryBuilder.GetPortablePdbQueryString(guid, stamp, fileName);
+                query = StoreQueryBuilder.GetPortablePdbQueryString(guid, fileName);
             }
             else
             {


### PR DESCRIPTION
This updates the proposed indexing scheme for portable PDBs to use the MVID plus UInt32.MaxValue as the age. This allows clients that are currently downloading Windows PDBs using symsrv.dll to pretty trivially download portable PDBs.

This also fixes some formatting problems with the .md files in this repo since GitHub now requires a space between the `#` character and the title.