### PR TITLE
Change System.Reflection.Metadata version back to 1.5

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,7 +11,7 @@
     <UsingToolXliff>false</UsingToolXliff>
 
     <!-- CoreFX -->
-    <SystemReflectionMetadataVersion>1.6.0-preview2-26406-04</SystemReflectionMetadataVersion>
+    <SystemReflectionMetadataVersion>1.5.0</SystemReflectionMetadataVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
The symbol client programs (SymClient and dotnet-symbol) and tools like SOS that will reference Microsoft.SymbolStore need to run on 2.0.