### PR TITLE
Upgrade to dotnet cli 2.1.400-preview-008999

### DIFF
--- a/eng/SignToolData.json
+++ b/eng/SignToolData.json
@@ -20,6 +20,7 @@
     }
   ],
   "exclude": [
+    "dotnet-symbol.exe",
     "Microsoft.CSharp.dll",
     "Microsoft.NETCore.Platforms",
     "System.Collections.Immutable.dll",

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,7 +5,7 @@
 
     <!-- This repo version -->
     <VersionPrefix>1.0.0</VersionPrefix>
-    <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>dev</PreReleaseVersionLabel>
 
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
     <UsingToolXliff>false</UsingToolXliff>

--- a/global.json
+++ b/global.json
@@ -1,8 +1,8 @@
 {
   "sdk": {
-    "version": "2.1.300"
+    "version": "2.1.400-preview-008999"
   },
   "msbuild-sdks": {
-    "RoslynTools.RepoToolset": "1.0.0-beta2-62810-01"
+    "RoslynTools.RepoToolset": "1.0.0-beta2-63011-08"
   }
 }

--- a/src/dotnet-symbol/README.md
+++ b/src/dotnet-symbol/README.md
@@ -1,6 +1,4 @@
-# Dotnet cli Symbol Downloader Utility #
-
-This is currently very preliminary.
+# Symbol downloader dotnet cli extension #
 
 This tool can download all the files needed for debugging (symbols, modules, SOS and DAC for the coreclr module given) for any given core dump, minidump or any supported platform's file formats like ELF, MachO, Windows DLLs, PDBs and portable PDBs.
       
@@ -26,9 +24,9 @@ This tool can download all the files needed for debugging (symbols, modules, SOS
 
 ## Install ##
 
-This is a dotnet global tool "extension" supported only in .NET Core 2.1. It is can be installed with the following command. The `<path-to-package>` is the packages built by this repo.
+This is a dotnet global tool "extension" supported only in [.NET Core 2.1](https://www.microsoft.com/net/download/). The latest version of the downloader can be installed with the following command.
 
-    dotnet tool install --global --source-feed <path-to-package> dotnet-symbol
+    dotnet tool install --global dotnet-symbol
 
 ## Examples ##
 
@@ -38,12 +36,24 @@ This will attempt to download all the modules, symbols and SOS/DAC files needed 
 
 To download the symbol files for a specific assembly:
 
-    dotnet symbol --symbols-only --cache-directory c:\temp\symcache --server-path http://symweb --output c:\temp\symout System.Threading.dll
+    dotnet symbol --symbols --cache-directory c:\temp\symcache --server-path http://symweb --output c:\temp\symout System.Threading.dll
 
 Downloads all the symbol files for the shared runtime:
 
-    dotnet symbol --symbols-only --output /tmp/symbols /usr/share/dotnet/shared/Microsoft.NETCore.App/2.0.0-preview3-25510-01/*
+    dotnet symbol --symbols --output /tmp/symbols /usr/share/dotnet/shared/Microsoft.NETCore.App/2.0.3/*
+
+After the symbols are downloaded to `/tmp/symbols` they can be copied back to the above runtime directory so the native debuggers like lldb or gdb can find them, but the copy needs to be superuser:
+
+	sudo cp /tmp/symbols/* /usr/share/dotnet/shared/Microsoft.NETCore.App/2.0.3
 
 To verify a symbol package on a local VSTS symbol server:
 
     dotnet symbol --authenticated-server-path x349x9dfkdx33333livjit4wcvaiwc3v4wjyvnq https://mikemvsts.artifacts.visualstudio.com/defaultcollection/_apis/Symbol/symsrv coredump.45634
+
+## Notes ##
+
+Core dumps generated with gdb (generate-core-file command) or gcore (utility that comes with gdb) do not currently work with this utility (issue [#47](https://github.com/dotnet/symstore/issues/47)).
+
+The best way to generate core dumps on Linux (not supported on Windows or OSX) is to use the [createdump](https://github.com/dotnet/coreclr/blob/master/Documentation/botr/xplat-minidump-generation.md) facility that is part of .NET Core 2.0 and greater. It can be setup to automatically generate a "minidump" like ELF core dump when your .NET Core app crashes. The normal Linux system core generation also works just fine but they are usually a lot larger than necessary.
+
+

--- a/src/dotnet-symbol/dotnet-symbol.csproj
+++ b/src/dotnet-symbol/dotnet-symbol.csproj
@@ -3,11 +3,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RuntimeFrameworkVersion>2.1.0</RuntimeFrameworkVersion>
     <NoWarn>;1591;1701</NoWarn>
     <IsPublishable>true</IsPublishable>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
-    <!-- The package version needs to be hard coded as a stable version so "dotnet install -g dotnet-symbols" works -->
+    <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86;osx-x64</PackAsToolShimRuntimeIdentifiers>
+    <!-- The package version needs to be hard coded as a stable version so "dotnet tool install -g dotnet-symbols" works -->
+    <Version>1.0.0</Version>
     <PackageVersion>1.0.0</PackageVersion>
     <ToolCommandName>dotnet-symbol</ToolCommandName>
     <Description>Symbols download utility</Description>


### PR DESCRIPTION
Add the properties needed to the dotnet-symbol project to
allow the shims be added to its package.

Update the roslyn repo set to 1.0.0-beta2-63011-08