### PR TITLE
Properly sign the shims for the dotnet-symbol tool.

### DIFF
--- a/eng/SignToolData.json
+++ b/eng/SignToolData.json
@@ -5,6 +5,8 @@
       "strongName": "MsSharedLib72",
       "values": [
         "bin/dotnet-symbol/netcoreapp2.1/dotnet-symbol.dll",
+        "bin/dotnet-symbol/shims/netcoreapp2.1/win-x64/dotnet-symbol.exe",
+        "bin/dotnet-symbol/shims/netcoreapp2.1/win-x86/dotnet-symbol.exe",
         "bin/Microsoft.FileFormats/net45/Microsoft.FileFormats.dll",
         "bin/Microsoft.FileFormats/netstandard1.5/Microsoft.FileFormats.dll",
         "bin/Microsoft.SymbolStore/net45/Microsoft.SymbolStore.dll",
@@ -20,7 +22,6 @@
     }
   ],
   "exclude": [
-    "dotnet-symbol.exe",
     "Microsoft.CSharp.dll",
     "Microsoft.NETCore.Platforms",
     "System.Collections.Immutable.dll",

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "2.1.400-preview-008999"
+    "version": "2.1.400-preview-009088"
   },
   "msbuild-sdks": {
     "RoslynTools.RepoToolset": "1.0.0-beta2-63021-06"

--- a/src/dotnet-symbol/dotnet-symbol.csproj
+++ b/src/dotnet-symbol/dotnet-symbol.csproj
@@ -17,6 +17,7 @@
     <PackageTags>Symbols</PackageTags>
     <PackageReleaseNotes>$(Description)</PackageReleaseNotes>
     <RootNamespace>dotnet.symbol</RootNamespace>
+    <PackagedShimOutputRootDirectory>$(OutputPath)</PackagedShimOutputRootDirectory>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Use the new .NET Core SDK that allows the global tool shims to be put in the output path so they can be properly signed.