### PR TITLE
Fix FreeBSD symbol uploader build failure issue #20722.

### DIFF
--- a/src/Microsoft.FileFormats.UnitTests/ELF/Tests.cs
+++ b/src/Microsoft.FileFormats.UnitTests/ELF/Tests.cs
@@ -55,6 +55,20 @@ namespace Microsoft.FileFormats.ELF.Tests
         }
 
         [Fact]
+        public void CheckFreeBSDIndexingInfo()
+        {
+            using (Stream stream = File.OpenRead("TestBinaries/ilasm.dbg"))
+            {
+                StreamAddressSpace dataSource = new StreamAddressSpace(stream);
+                ELFFile elf = new ELFFile(dataSource);
+                Assert.True(elf.IsValid());
+                Assert.True(elf.Header.Type == ELFHeaderType.Executable);
+                string buildId = TestUtilities.ToHexString(elf.BuildID);
+                Assert.Equal("4a91e41002a1307ef4097419d7875df001969daa", buildId);
+            }
+        }
+
+        [Fact]
         public void ParseCore()
         {
             using (Stream core = TestUtilities.OpenCompressedFile("TestBinaries/core.gz"))

--- a/src/Microsoft.FileFormats.UnitTests/Microsoft.FileFormats.UnitTests.csproj
+++ b/src/Microsoft.FileFormats.UnitTests/Microsoft.FileFormats.UnitTests.csproj
@@ -42,6 +42,9 @@
     <Content Include="TestBinaries\triagedump.gz">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="TestBinaries\ilasm.dbg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
FreeBSD .dbg binaries don't have program entries. Use the section entries
to find the build id if so.

https://github.com/dotnet/coreclr/issues/20722