### PR TITLE
Misc fixes and changes.

### DIFF
--- a/src/Microsoft.SymbolStore/KeyGenerators/ELFFileKeyGenerator.cs
+++ b/src/Microsoft.SymbolStore/KeyGenerators/ELFFileKeyGenerator.cs
@@ -87,7 +87,7 @@ namespace Microsoft.SymbolStore.KeyGenerators
                 }
                 else
                 {
-                    bool clrSpecialFile = s_coreClrSpecialFiles.Contains(Path.GetFileName(path));
+                    bool clrSpecialFile = s_coreClrSpecialFiles.Contains(GetFileName(path));
                     yield return BuildKey(path, IdentityPrefix, buildId, clrSpecialFile);
                 }
             }
@@ -104,7 +104,7 @@ namespace Microsoft.SymbolStore.KeyGenerators
                 if ((flags & KeyTypeFlags.ClrKeys) != 0)
                 {
                     /// Creates all the special CLR keys if the path is the coreclr module for this platform
-                    if (Path.GetFileName(path) == CoreClrFileName)
+                    if (GetFileName(path) == CoreClrFileName)
                     {
                         foreach (string specialFileName in s_coreClrSpecialFiles)
                         {

--- a/src/Microsoft.SymbolStore/KeyGenerators/KeyGenerator.cs
+++ b/src/Microsoft.SymbolStore/KeyGenerators/KeyGenerator.cs
@@ -88,9 +88,7 @@ namespace Microsoft.SymbolStore.KeyGenerators
         /// <returns>key</returns>
         protected static SymbolStoreKey BuildKey(string path, string id, bool clrSpecialFile = false)
         {
-            // The back slashes are changed to forward slashes because Path.GetFileName doesn't work on 
-            // Linux /MacOS if there are backslashes. Both back and forward slashes work on Windows.
-            string file = Uri.EscapeDataString(Path.GetFileName(path.Replace('\\', '/')).ToLowerInvariant());
+            string file = Uri.EscapeDataString(GetFileName(path).ToLowerInvariant());
             return BuildKey(path, null, id, file, clrSpecialFile);
         }
 
@@ -104,7 +102,7 @@ namespace Microsoft.SymbolStore.KeyGenerators
         /// <returns>key</returns>
         protected static SymbolStoreKey BuildKey(string path, string prefix, byte[] id, bool clrSpecialFile = false)
         {
-            string file = Uri.EscapeDataString(Path.GetFileName(path.Replace('\\', '/')).ToLowerInvariant());
+            string file = Uri.EscapeDataString(GetFileName(path).ToLowerInvariant());
             return BuildKey(path, prefix, id, file, clrSpecialFile);
         }
 
@@ -159,6 +157,17 @@ namespace Microsoft.SymbolStore.KeyGenerators
                 throw new ArgumentNullException(nameof(bytes));
             }
             return string.Concat(bytes.Select(b => b.ToString("x2")));
+        }
+
+        /// <summary>
+        /// The back slashes are changed to forward slashes because Path.GetFileName doesn't work 
+        /// on Linux /MacOS if there are backslashes. Both back and forward slashes work on Windows.
+        /// </summary>
+        /// <param name="path">possible windows path</param>
+        /// <returns>just the file name</returns>
+        internal static string GetFileName(string path)
+        {
+            return Path.GetFileName(path.Replace('\\', '/'));
         }
     }
 }

--- a/src/Microsoft.SymbolStore/KeyGenerators/MachOKeyGenerator.cs
+++ b/src/Microsoft.SymbolStore/KeyGenerators/MachOKeyGenerator.cs
@@ -88,7 +88,7 @@ namespace Microsoft.SymbolStore.KeyGenerators
                 }
                 else
                 {
-                    bool clrSpecialFile = s_coreClrSpecialFiles.Contains(Path.GetFileName(path));
+                    bool clrSpecialFile = s_coreClrSpecialFiles.Contains(GetFileName(path));
                     yield return BuildKey(path, IdentityPrefix, uuid, clrSpecialFile);
                 }
             }
@@ -105,7 +105,7 @@ namespace Microsoft.SymbolStore.KeyGenerators
                 if ((flags & KeyTypeFlags.ClrKeys) != 0)
                 {
                     /// Creates all the special CLR keys if the path is the coreclr module for this platform
-                    if (Path.GetFileName(path) == CoreClrFileName)
+                    if (GetFileName(path) == CoreClrFileName)
                     {
                         foreach (string specialFileName in s_coreClrSpecialFiles)
                         {

--- a/src/Microsoft.SymbolStore/KeyGenerators/PEFileKeyGenerator.cs
+++ b/src/Microsoft.SymbolStore/KeyGenerators/PEFileKeyGenerator.cs
@@ -70,7 +70,7 @@ namespace Microsoft.SymbolStore.KeyGenerators
                 }
                 if ((flags & KeyTypeFlags.ClrKeys) != 0)
                 {
-                    if (Path.GetFileName(_path.Replace('\\', '/')) == CoreClrFileName)
+                    if (GetFileName(_path) == CoreClrFileName)
                     {
                         string coreclrId = string.Format("{0:x}{1:x}", _peFile.Timestamp, _peFile.SizeOfImage);
                         foreach (string specialFileName in GetSpecialFiles())
@@ -161,7 +161,7 @@ namespace Microsoft.SymbolStore.KeyGenerators
 
             // The clr special file flag can not be based on the GetSpecialFiles() list because 
             // that is only valid when "path" is the coreclr.dll.
-            string fileName = Path.GetFileName(path.Replace('\\', '/'));
+            string fileName = GetFileName(path);
             bool clrSpecialFile = s_coreClrSpecialFiles.Contains(fileName) || 
                 (s_longNameBinaryPrefixes.Any((prefix) => fileName.StartsWith(prefix)) && Path.GetExtension(fileName) == ".dll");
 

--- a/src/Microsoft.SymbolStore/SymbolStores/CacheSymbolStore.cs
+++ b/src/Microsoft.SymbolStore/SymbolStores/CacheSymbolStore.cs
@@ -9,12 +9,12 @@ namespace Microsoft.SymbolStore.SymbolStores
 {
     public sealed class CacheSymbolStore : SymbolStore
     {
-        private readonly string _cacheDirectory;
+        public string CacheDirectory { get; }
 
         public CacheSymbolStore(ITracer tracer, SymbolStore backingStore, string cacheDirectory)
             : base(tracer, backingStore)
         {
-            _cacheDirectory = cacheDirectory ?? throw new ArgumentNullException(nameof(cacheDirectory));
+            CacheDirectory = cacheDirectory ?? throw new ArgumentNullException(nameof(cacheDirectory));
             Directory.CreateDirectory(cacheDirectory);
         }
 
@@ -47,7 +47,7 @@ namespace Microsoft.SymbolStore.SymbolStores
         private string GetCacheFilePath(SymbolStoreKey key)
         {
             if (SymbolStoreKey.IsKeyValid(key.Index)) {
-                return Path.Combine(_cacheDirectory, key.Index);
+                return Path.Combine(CacheDirectory, key.Index);
             }
             Tracer.Error("CacheSymbolStore: invalid key index {0}", key.Index);
             return null;

--- a/src/Microsoft.SymbolStore/SymbolStores/SymbolStore.cs
+++ b/src/Microsoft.SymbolStore/SymbolStores/SymbolStore.cs
@@ -12,7 +12,7 @@ namespace Microsoft.SymbolStore.SymbolStores
         /// <summary>
         /// Next symbol store to chain if this store refuses the request
         /// </summary>
-        private readonly SymbolStore _backingStore;
+        public SymbolStore BackingStore { get; }
 
         /// <summary>
         /// Trace/logging source
@@ -27,7 +27,7 @@ namespace Microsoft.SymbolStore.SymbolStores
         public SymbolStore(ITracer tracer, SymbolStore backingStore)
             : this(tracer)
         {
-            _backingStore = backingStore;
+            BackingStore = backingStore;
         }
 
         /// <summary>
@@ -41,9 +41,9 @@ namespace Microsoft.SymbolStore.SymbolStores
             SymbolStoreFile file = await GetFileInner(key, token);
             if (file == null)
             {
-                if (_backingStore != null)
+                if (BackingStore != null)
                 {
-                    file = await _backingStore.GetFile(key, token);
+                    file = await BackingStore.GetFile(key, token);
                     if (file != null)
                     {
                         await WriteFileInner(key, file);
@@ -68,9 +68,9 @@ namespace Microsoft.SymbolStore.SymbolStores
 
         public virtual void Dispose()
         {
-            if (_backingStore != null)
+            if (BackingStore != null)
             {
-                _backingStore.Dispose();
+                BackingStore.Dispose();
             }
         }
     }

--- a/src/NugetSymbolServer/NugetSymbolServer.csproj
+++ b/src/NugetSymbolServer/NugetSymbolServer.csproj
@@ -1,8 +1,8 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="RoslynTools.RepoToolset">
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-    <IsTool>true</IsTool>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <Description>Simple nuget package symbol server</Description>
     <PackageTags>Symbol Server</PackageTags>
     <PackageReleaseNotes>$(Description)</PackageReleaseNotes>
@@ -10,21 +10,24 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="1.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.1.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <Content Update="config.json">
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    <Content Include="config.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <PackagePath>tools\</PackagePath>
     </Content>
-    <Content Update="Properties\launchSettings.json">
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    <Content Include="Properties\launchSettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <PackagePath>tools\</PackagePath>
+    </Content>
+    <Content Include="nuget_feed\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 </Project>

--- a/src/NugetSymbolServer/README.md
+++ b/src/NugetSymbolServer/README.md
@@ -4,14 +4,20 @@ This is a proof of concept implementation of a [Package Based Symbol Server](../
 
 ## Running the example ##
 
-Step 1 - Start a command line in this directory and run:
+Step 1 - Build the symstore repo
+    
+    c:\repos\symstore> build.cmd
 
-    NugetSymbolServer>dotnet restore
-       ...
-    NugetSymbolServer>dotnet run
-       ...
+Step 2 - Run the symbol server
+
+    c:\repos\symstore> dotnet artifacts\Debug\bin\NugetSymbolServer\netcoreapp2.1\NugetSymbolServer.dll
+
+    info: NugetSymbolServer.Service.Models.PackageStore[0]
+          Adding package c:\repos\symstore\artifacts\Debug\bin\NugetSymbolServer\netcoreapp2.1\.\nuget_feed\HelloWorld.1.0.0.nupkg
+    info: NugetSymbolServer.Service.Models.PackageBasedSymbolStore[0]
+          Adding symbol entry helloworld.dll/57847aae8000/helloworld.dll => C:\Users\mikem\AppData\Local\Temp\NugetSymbolServerFileCache\HelloWorld.1.0.0\1\lib\netcoreapp1.0\HelloWorld.dll
     Hosting environment: Production
-    Content root path: F:\github\symstore\src\samples\NugetSymbolServer\bin\Debug\netcoreapp1.0
+    Content root path: c:\repos\symstore\artifacts\Debug\bin\NugetSymbolServer\netcoreapp2.1\
     Now listening on: http://localhost:5000
     Application started. Press Ctrl+C to shut down.
 
@@ -19,8 +25,11 @@ Step 2 - Use your favorite web browser to send an SSQP request
 
     http://localhost:5000/symbol/HelloWorld.dll/57847aae8000/HelloWorld.dll
 
-Congratulations, you just made an request and downloaded a file. Normally a diagnostic tool would make this request on your behalf, for example when debugging a dump that was running the HelloWorld application.
+or use the dotnet symbol tool (after installing it):
 
+    dotnet symbol --server-path http://localhost:5000 <path>\HelloWorld.dll
+
+Congratulations, you just made an request and downloaded a file. Normally a diagnostic tool would make this request on your behalf, for example when debugging a dump that was running the HelloWorld application.
 
 ## Further exploration ##
 

--- a/src/NugetSymbolServer/Startup.cs
+++ b/src/NugetSymbolServer/Startup.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.PlatformAbstractions;
 using NugetSymbolServer.Service.Models;
 using System;
 using System.IO;
@@ -15,8 +15,6 @@ namespace NugetSymbolServer
     {
         public Startup(IHostingEnvironment hostingEnvironment, IConfigurationSource hostProvidedConfiguration)
         { 
-            ApplicationEnvironment = PlatformServices.Default.Application;  
-
             Configuration = 
                 new ConfigurationBuilder()
                 .SetBasePath(ApplicationEnvironment.ApplicationBasePath)
@@ -40,8 +38,6 @@ namespace NugetSymbolServer
         public IConfiguration Configuration { get; private set; } 
  
         public IConfiguration LoggingConfiguration { get; private set; }
-
-        public ApplicationEnvironment ApplicationEnvironment { get; private set; }
 
         public void ConfigureServices(IServiceCollection services)
         {

--- a/src/SymClient/Program.cs
+++ b/src/SymClient/Program.cs
@@ -451,7 +451,7 @@ SymClient [options] <files>
         private async Task WriteFileToDirectory(Stream stream, string fileName, string destinationDirectory)
         {
             stream.Position = 0;
-            string destination = Path.Combine(destinationDirectory, Path.GetFileName(fileName));
+            string destination = Path.Combine(destinationDirectory, Path.GetFileName(fileName.Replace('\\', '/')));
             if (File.Exists(destination)) {
                 Tracer.Warning("Writing: {0} already exists", destination);
             }

--- a/src/SymClient/SymClient.csproj
+++ b/src/SymClient/SymClient.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="RoslynTools.RepoToolset">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <NoWarn>;1591;1701</NoWarn>
     <IsTool>true</IsTool>

--- a/src/dotnet-symbol/Program.cs
+++ b/src/dotnet-symbol/Program.cs
@@ -362,17 +362,14 @@ namespace dotnet.symbol
 
         private static string GetDefaultSymbolCache()
         {
-            string environmentVar;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                environmentVar = "USERPROFILE";
+                return Path.Combine(Path.GetTempPath(), "SymbolCache");
             }
             else
             {
-                environmentVar = "HOME";
+                return Path.Combine(Environment.GetEnvironmentVariable("HOME"), ".dotnet", "symbolcache");
             }
-            string userPath = Environment.GetEnvironmentVariable(environmentVar);
-            return Path.GetFullPath(Path.Combine(userPath, ".dotnet", "symbolcache"));
         }
     }
 }

--- a/src/dotnet-symbol/dotnet-symbol.csproj
+++ b/src/dotnet-symbol/dotnet-symbol.csproj
@@ -10,8 +10,8 @@
     <PackAsTool>true</PackAsTool>
     <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86;osx-x64</PackAsToolShimRuntimeIdentifiers>
     <!-- The package version needs to be hard coded as a stable version so "dotnet tool install -g dotnet-symbols" works -->
-    <Version>1.0.0</Version>
-    <PackageVersion>1.0.0</PackageVersion>
+    <Version>1.0.1</Version>
+    <PackageVersion>1.0.1</PackageVersion>
     <ToolCommandName>dotnet-symbol</ToolCommandName>
     <Description>Symbols download utility</Description>
     <PackageTags>Symbols</PackageTags>


### PR DESCRIPTION
Fixed Path.GetFileName on Windows paths running on Linux.

Fixed NugetSymbolServer project.

Fixed issue #83 and GitHub security alert about Microsoft.AspNetCore.Mvc.

changed dotnet-symbol version to 1.0.1.

Added default cache.

The same location as the SOS symbol server support.

$HOME/.dotnet/symbolcache on xplat.
%USERPROFILE%\.dotnet\symbolcache on Windows.