### PR TITLE
Various dotnet-symbol and symstore fixes

### DIFF
--- a/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs
+++ b/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs
@@ -41,8 +41,11 @@ namespace Microsoft.SymbolStore.SymbolStores
             {
                 throw new ArgumentException(nameof(symbolServerUri));
             }
+
             // Normal unauthenticated client
-            _client = new HttpClient();
+            _client = new HttpClient {
+                Timeout = TimeSpan.FromMinutes(4)
+            };
 
             // If PAT, create authenticated client
             if (!string.IsNullOrEmpty(personalAccessToken))
@@ -50,7 +53,9 @@ namespace Microsoft.SymbolStore.SymbolStores
                 var handler = new HttpClientHandler() {
                     AllowAutoRedirect = false
                 };
-                var client = new HttpClient(handler);
+                var client = new HttpClient(handler) {
+                    Timeout = TimeSpan.FromMinutes(4)
+                };
                 client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
                     "Basic", Convert.ToBase64String(ASCIIEncoding.ASCII.GetBytes(string.Format("{0}:{1}", "", personalAccessToken))));

--- a/src/dotnet-symbol/dotnet-symbol.csproj
+++ b/src/dotnet-symbol/dotnet-symbol.csproj
@@ -11,7 +11,7 @@
     <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86;osx-x64</PackAsToolShimRuntimeIdentifiers>
     <!-- The package version needs to be hard coded as a stable version so "dotnet tool install -g dotnet-symbols" works -->
     <Version>1.0.1</Version>
-    <PackageVersion>1.0.1</PackageVersion>
+    <PackageVersion>1.0.2</PackageVersion>
     <ToolCommandName>dotnet-symbol</ToolCommandName>
     <Description>Symbols download utility</Description>
     <PackageTags>Symbols</PackageTags>


### PR DESCRIPTION
This is an accumulation of dotnet-symbol/symstore fixes.

Fix reads across contiguous adjacent segments. This is the same problem and changes applied to the CLRMD's ELF dump reader recently.

Catch exceptions around create cache directory. This catches and skip caching when the cached file was written previously as superuser.  

Increase the request timeout from 100 seconds (1:40min) to 4 minutes. Issue #87.