### PR TITLE
Update the dotnet-symbol version 1.0.5

### DIFF
--- a/src/dotnet-symbol/dotnet-symbol.csproj
+++ b/src/dotnet-symbol/dotnet-symbol.csproj
@@ -10,7 +10,7 @@
     <PackAsTool>true</PackAsTool>
     <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86;osx-x64</PackAsToolShimRuntimeIdentifiers>
     <!-- The package version needs to be hard coded as a stable version so "dotnet tool install -g dotnet-symbols" works -->
-    <Version>1.0.4</Version>
+    <Version>1.0.5</Version>
     <PackageVersion>$(Version)</PackageVersion>
     <ToolCommandName>dotnet-symbol</ToolCommandName>
     <Description>Symbols download utility</Description>

--- a/src/dotnet-symbol/runtimeconfig.template.json
+++ b/src/dotnet-symbol/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+  "rollForwardOnNoCandidateFx": 2
+}


### PR DESCRIPTION
Add roll forward config to allow dotnet-symbol to work on 2.2.x and 3.0.x runtimes.