### PR TITLE
Restore stream position after checksum validation

### DIFF
--- a/src/Microsoft.SymbolStore/ChecksumValidator.cs
+++ b/src/Microsoft.SymbolStore/ChecksumValidator.cs
@@ -59,6 +59,8 @@ namespace Microsoft.SymbolStore
                         tracer.Information($"Found checksum match {checksum}");
                         // Restore the pdb Id
                         Array.Copy(pdbId, 0, bytes, offset, pdbIdSize);
+                        // Restore the steam position
+                        pdbStream.Seek(0, SeekOrigin.Begin);
 
                         return;
                     }


### PR DESCRIPTION
At least on CoreCLR using the symbol store's caching reader, the stream position needs to be restored after checksum validation or it will be omitted from the file. This adds code to do this.