### PR TITLE
[SSQP_Key_Conventions.md] Fix wrong lookup key

### DIFF
--- a/docs/specs/SSQP_Key_Conventions.md
+++ b/docs/specs/SSQP_Key_Conventions.md
@@ -28,7 +28,7 @@ Example:
 
 **COFF header SizeOfImage field:** `0x32000`
 
-**Lookup key:** `foo.exe/542d574200032000/foo.exe`
+**Lookup key:** `foo.exe/542d574232000/foo.exe`
 
 
 ### PDB-Signature-Age


### PR DESCRIPTION
According to the "Key formatting basic rules", the leading zeros should be trimmed.