### PR TITLE
Fix various issues

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,6 +19,7 @@
     <EnableSourceControlManagerQueries>true</EnableSourceControlManagerQueries>
     <IsShipping>true</IsShipping>
     <NoPackageAnalysis>true</NoPackageAnalysis>
+    <IsShippingAssembly>false</IsShippingAssembly>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,6 +61,7 @@ jobs:
       - script: eng\common\cibuild.cmd
           -configuration $(_BuildConfig)
           -prepareMachine
+          -verbosity normal
           $(_SignArgs)
           $(_PublishArgs)
           $(_OfficialBuildIdArgs)

--- a/src/Microsoft.FileFormats/ELF/ELFStructures.cs
+++ b/src/Microsoft.FileFormats/ELF/ELFStructures.cs
@@ -138,7 +138,7 @@ namespace Microsoft.FileFormats.ELF
         {
             get
             {
-                return new ValidationRule("Unreasonably large ELFHeader ProgramHeaderCount", () => ProgramHeaderCount <= 10000);
+                return new ValidationRule("Unreasonably large ELFHeader ProgramHeaderCount", () => ProgramHeaderCount <= 30000);
             }
         }
 
@@ -146,7 +146,7 @@ namespace Microsoft.FileFormats.ELF
         {
             get
             {
-                return new ValidationRule("Unreasonably large ELFHeader SectionHeaderCount", () => SectionHeaderCount <= 10000);
+                return new ValidationRule("Unreasonably large ELFHeader SectionHeaderCount", () => SectionHeaderCount <= 30000);
             }
         }
 

--- a/src/Microsoft.FileFormats/Microsoft.FileFormats.csproj
+++ b/src/Microsoft.FileFormats/Microsoft.FileFormats.csproj
@@ -8,5 +8,6 @@
     <PackageReleaseNotes>$(Description)</PackageReleaseNotes>
     <PackageTags>File formats</PackageTags>
     <IncludeSymbols>true</IncludeSymbols>
+    <IsShippingAssembly>true</IsShippingAssembly>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.SymbolStore/Microsoft.SymbolStore.csproj
+++ b/src/Microsoft.SymbolStore/Microsoft.SymbolStore.csproj
@@ -8,6 +8,7 @@
     <PackageReleaseNotes>$(Description)</PackageReleaseNotes>
     <PackageTags>Symbol Indexing</PackageTags>
     <IncludeSymbols>true</IncludeSymbols>
+    <IsShippingAssembly>true</IsShippingAssembly>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Microsoft.SymbolStore/SymbolStores/CacheSymbolStore.cs
+++ b/src/Microsoft.SymbolStore/SymbolStores/CacheSymbolStore.cs
@@ -57,5 +57,24 @@ namespace Microsoft.SymbolStore.SymbolStores
             Tracer.Error("CacheSymbolStore: invalid key index {0}", key.Index);
             return null;
         }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is CacheSymbolStore store)
+            {
+                return CacheDirectory.Equals(store.CacheDirectory);
+            }
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return CacheDirectory.GetHashCode();
+        }
+
+        public override string ToString()
+        {
+            return $"Cache: {CacheDirectory}";
+        }
     }
 }

--- a/src/Microsoft.SymbolStore/SymbolStores/DirectorySymbolStore.cs
+++ b/src/Microsoft.SymbolStore/SymbolStores/DirectorySymbolStore.cs
@@ -67,5 +67,24 @@ namespace SOS
 
             return Task.FromResult(result);
         }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is DirectorySymbolStore store)
+            {
+                return Directory.Equals(store.Directory);
+            }
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return Directory.GetHashCode();
+        }
+
+        public override string ToString()
+        {
+            return $"Directory: {Directory}";
+        }
     }
 }

--- a/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs
+++ b/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.FileFormats.PE;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -8,7 +7,6 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Net.NetworkInformation;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -201,6 +199,25 @@ namespace Microsoft.SymbolStore.SymbolStores
         protected void MarkClientFailure()
         {
             _clientFailure = true;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is HttpSymbolStore store)
+            {
+                return Uri.Equals(store.Uri);
+            }
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return Uri.GetHashCode();
+        }
+
+        public override string ToString()
+        {
+            return $"Server: {Uri}";
         }
     }
 }

--- a/src/Microsoft.SymbolStore/SymbolStores/SymbolStore.cs
+++ b/src/Microsoft.SymbolStore/SymbolStores/SymbolStore.cs
@@ -51,11 +51,14 @@ namespace Microsoft.SymbolStore.SymbolStores
                     if (file != null)
                     {
                         await WriteFileInner(key, file);
-
-                        // Reset stream to the beginning for next symbol store
-                        file.Stream.Position = 0;
                     }
                 }
+            }
+            if (file != null)
+            {
+                // Reset stream to the beginning because the stream may have
+                // been read or written by the symbol store implementation.
+                file.Stream.Position = 0;
             }
             return file;
         }

--- a/src/dotnet-symbol/README.md
+++ b/src/dotnet-symbol/README.md
@@ -52,7 +52,7 @@ To verify a symbol package on a local VSTS symbol server:
 
 ## Notes ##
 
-Symbol download is only supported for official .NET Core runtime versions installed from our official [web site](https://dotnet.microsoft.com/download/dotnet-core). Runtimes from community sites like [archlinux](https://www.archlinux.org/packages/community/x86_64/dotnet-runtime/) are not support. 
+Symbol download is only supported for official .NET Core runtime versions acquired through official channels such as [the official web site](https://dotnet.microsoft.com/download/dotnet-core) and the [default sources in the dotnet installation scripts](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-scripts). Runtimes obtained from community sites like [archlinux](https://www.archlinux.org/packages/community/x86_64/dotnet-runtime/) are not supported. 
 
 Core dumps generated with gdb (generate-core-file command) or gcore (utility that comes with gdb) do not currently work with this utility (issue [#47](https://github.com/dotnet/symstore/issues/47)).
 

--- a/src/dotnet-symbol/README.md
+++ b/src/dotnet-symbol/README.md
@@ -52,6 +52,8 @@ To verify a symbol package on a local VSTS symbol server:
 
 ## Notes ##
 
+Symbol download is only supported for official .NET Core runtime versions installed from our official [web site](https://dotnet.microsoft.com/download/dotnet-core). Runtimes from community sites like [archlinux](https://www.archlinux.org/packages/community/x86_64/dotnet-runtime/) are not support. 
+
 Core dumps generated with gdb (generate-core-file command) or gcore (utility that comes with gdb) do not currently work with this utility (issue [#47](https://github.com/dotnet/symstore/issues/47)).
 
 The best way to generate core dumps on Linux (not supported on Windows or OSX) is to use the [createdump](https://github.com/dotnet/coreclr/blob/master/Documentation/botr/xplat-minidump-generation.md#configurationpolicy) facility that is part of .NET Core 2.0 and greater. It can be setup to automatically generate a "minidump" like ELF core dump when your .NET Core app crashes. The normal Linux system core generation also works just fine but they are usually a lot larger than necessary.


### PR DESCRIPTION
Fix some symbol publishing problems.

Fix issue #130 by increasing the section/program header count to 30000.

Fix issue #117. Always set the symbol file stream position to 0.

Add Equals, GetHashCode and ToString to the SymbolStore implementations

Fix issue #106.