### PR TITLE
Host program support

### DIFF
--- a/src/Microsoft.FileFormats/PE/PEStructures.cs
+++ b/src/Microsoft.FileFormats/PE/PEStructures.cs
@@ -105,11 +105,11 @@ namespace Microsoft.FileFormats.PE
     [Flags]
     public enum ImageFile : ushort
     {
-        RELOCS_STRIPPED         = 0x0001,
-        EXECUTABLE_IMAGE        = 0x0002,
-        LARGE_ADDRESS_AWARE     = 0x0020,
-        SYSTEM                  = 0x1000,
-        DLL                     = 0x2000,
+        RelocsStripped      = 0x0001,
+        ExecutableImage     = 0x0002,
+        LargeAddressAware   = 0x0020,
+        System              = 0x1000,
+        Dll                 = 0x2000,
     }
 
     /// <summary>

--- a/src/Microsoft.FileFormats/PE/PEStructures.cs
+++ b/src/Microsoft.FileFormats/PE/PEStructures.cs
@@ -100,6 +100,19 @@ namespace Microsoft.FileFormats.PE
     }
 
     /// <summary>
+    /// Characteristics (IMAGE_FILE)
+    /// </summary>
+    [Flags]
+    public enum ImageFile : ushort
+    {
+        RELOCS_STRIPPED         = 0x0001,
+        EXECUTABLE_IMAGE        = 0x0002,
+        LARGE_ADDRESS_AWARE     = 0x0020,
+        SYSTEM                  = 0x1000,
+        DLL                     = 0x2000,
+    }
+
+    /// <summary>
     /// IMAGE_FILE_HEADER struct
     /// </summary>
     public class ImageFileHeader : TStruct

--- a/src/Microsoft.SymbolStore/KeyGenerators/ELFFileKeyGenerator.cs
+++ b/src/Microsoft.SymbolStore/KeyGenerators/ELFFileKeyGenerator.cs
@@ -57,6 +57,17 @@ namespace Microsoft.SymbolStore.KeyGenerators
                     {
                         yield return key;
                     }
+                    if ((flags & KeyTypeFlags.HostKeys) != 0)
+                    {
+                        if (_elfFile.Header.Type == ELFHeaderType.Executable)
+                        {
+                            // The host program as itself (usually dotnet)
+                            yield return BuildKey(_path, IdentityPrefix, buildId);
+
+                            // apphost downloaded as the host program name
+                            yield return BuildKey(_path, IdentityPrefix, buildId, "apphost");
+                        }
+                    }
                 }
                 else
                 {

--- a/src/Microsoft.SymbolStore/KeyGenerators/KeyGenerator.cs
+++ b/src/Microsoft.SymbolStore/KeyGenerators/KeyGenerator.cs
@@ -3,13 +3,15 @@
 using Microsoft.FileFormats.PE;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
 
 namespace Microsoft.SymbolStore.KeyGenerators
 {
+    /// <summary>
+    /// Type of keys to generate
+    /// </summary>
     [Flags]
     public enum KeyTypeFlags
     {
@@ -39,6 +41,11 @@ namespace Microsoft.SymbolStore.KeyGenerators
         /// the Portable and Windows PDBs are available on the symbol server.
         /// </summary>
         ForceWindowsPdbs = 0x08,
+
+        /// <summary>
+        /// Generate keys for the host program.
+        /// </summary>
+        HostKeys = 0x10
     }
 
     /// <summary>

--- a/src/Microsoft.SymbolStore/KeyGenerators/KeyGenerator.cs
+++ b/src/Microsoft.SymbolStore/KeyGenerators/KeyGenerator.cs
@@ -43,7 +43,9 @@ namespace Microsoft.SymbolStore.KeyGenerators
         ForceWindowsPdbs = 0x08,
 
         /// <summary>
-        /// Generate keys for the host program.
+        /// Generate keys for the host program. This includes the exe or main
+        /// module key (usually "dotnet") and an "apphost" symbol index using 
+        /// the exe or main module's build id for self-contained apps.
         /// </summary>
         HostKeys = 0x10
     }

--- a/src/Microsoft.SymbolStore/KeyGenerators/MachOKeyGenerator.cs
+++ b/src/Microsoft.SymbolStore/KeyGenerators/MachOKeyGenerator.cs
@@ -58,6 +58,17 @@ namespace Microsoft.SymbolStore.KeyGenerators
                     {
                         yield return key;
                     }
+                    if ((flags & KeyTypeFlags.HostKeys) != 0)
+                    {
+                        if (_machoFile.Header.FileType == MachHeaderFileType.Execute)
+                        {
+                            // The host program as itself (usually dotnet)
+                            yield return BuildKey(_path, IdentityPrefix, uuid);
+
+                            // apphost downloaded as the host program name
+                            yield return BuildKey(_path, IdentityPrefix, uuid, "apphost");
+                        }
+                    }
                 }
                 else
                 {

--- a/src/Microsoft.SymbolStore/KeyGenerators/PDBFileKeyGenerator.cs
+++ b/src/Microsoft.SymbolStore/KeyGenerators/PDBFileKeyGenerator.cs
@@ -49,7 +49,7 @@ namespace Microsoft.SymbolStore.KeyGenerators
         {
             Debug.Assert(path != null);
             Debug.Assert(signature != null);
-            return BuildKey(path, string.Format("{0}{1:x}", signature.ToString("N"), age, pdbChecksums));
+            return BuildKey(path, string.Format("{0}{1:x}", signature.ToString("N"), age));
         }
     }
 }

--- a/src/Microsoft.SymbolStore/KeyGenerators/PEFileKeyGenerator.cs
+++ b/src/Microsoft.SymbolStore/KeyGenerators/PEFileKeyGenerator.cs
@@ -81,6 +81,19 @@ namespace Microsoft.SymbolStore.KeyGenerators
                         }
                     }
                 }
+                if ((flags & KeyTypeFlags.HostKeys) != 0)
+                {
+                    if ((_peFile.FileHeader.Characteristics & (ushort)ImageFile.DLL) == 0 && !_peFile.IsILImage)
+                    {
+                        string id = string.Format("{0:x}{1:x}", _peFile.Timestamp, _peFile.SizeOfImage);
+
+                        // The host program as itself (usually dotnet.exe)
+                        yield return BuildKey(_path, id);
+
+                        // apphost.exe downloaded as the host program name
+                        yield return BuildKey(_path, prefix: null, id, "apphost.exe");
+                    }
+                }
             }
         }
 

--- a/src/Microsoft.SymbolStore/KeyGenerators/PEFileKeyGenerator.cs
+++ b/src/Microsoft.SymbolStore/KeyGenerators/PEFileKeyGenerator.cs
@@ -83,7 +83,7 @@ namespace Microsoft.SymbolStore.KeyGenerators
                 }
                 if ((flags & KeyTypeFlags.HostKeys) != 0)
                 {
-                    if ((_peFile.FileHeader.Characteristics & (ushort)ImageFile.DLL) == 0 && !_peFile.IsILImage)
+                    if ((_peFile.FileHeader.Characteristics & (ushort)ImageFile.Dll) == 0 && !_peFile.IsILImage)
                     {
                         string id = string.Format("{0:x}{1:x}", _peFile.Timestamp, _peFile.SizeOfImage);
 

--- a/src/Microsoft.SymbolStore/KeyGenerators/PortablePDBFileKeyGenerator.cs
+++ b/src/Microsoft.SymbolStore/KeyGenerators/PortablePDBFileKeyGenerator.cs
@@ -81,7 +81,7 @@ namespace Microsoft.SymbolStore.KeyGenerators
         {
             Debug.Assert(path != null);
             Debug.Assert(pdbId != null);
-            return BuildKey(path, pdbId.ToString("N") + "FFFFFFFF", false, pdbChecksums);
+            return BuildKey(path, pdbId.ToString("N") + "FFFFFFFF", clrSpecialFile: false, pdbChecksums);
         }
     }
 }

--- a/src/dotnet-symbol/Program.cs
+++ b/src/dotnet-symbol/Program.cs
@@ -32,6 +32,7 @@ namespace dotnet.symbol
         private bool Debugging;
         private bool Modules;
         private bool ForceWindowsPdbs;
+        private bool HostOnly;
         private ITracer Tracer;
 
         public static void Main(string[] args)
@@ -123,6 +124,10 @@ namespace dotnet.symbol
 
                     case "--windows-pdbs":
                         program.ForceWindowsPdbs = true;
+                        break;
+
+                    case "--host-only":
+                        program.HostOnly = true;
                         break;
 
                     case "-d":
@@ -283,6 +288,10 @@ namespace dotnet.symbol
                 foreach (KeyGenerator generator in GetKeyGenerators(inputFile))
                 {
                     KeyTypeFlags flags = KeyTypeFlags.None;
+                    if (HostOnly)
+                    {
+                        flags = KeyTypeFlags.HostKeys;
+                    }
                     if (Symbols)
                     {
                         flags |= KeyTypeFlags.SymbolKey;
@@ -300,7 +309,7 @@ namespace dotnet.symbol
                         if (generator.IsDump())
                         {
                             // The default for dumps is to download everything
-                            flags = KeyTypeFlags.IdentityKey | KeyTypeFlags.SymbolKey | KeyTypeFlags.ClrKeys;
+                            flags = KeyTypeFlags.IdentityKey | KeyTypeFlags.SymbolKey | KeyTypeFlags.ClrKeys | KeyTypeFlags.HostKeys;
                         }
                         else
                         {

--- a/src/dotnet-symbol/Properties/Resources.resx
+++ b/src/dotnet-symbol/Properties/Resources.resx
@@ -145,6 +145,7 @@ Options:
   --authenticated-server-path &lt;pat&gt; &lt;server path&gt;   Add a http PAT authenticated server path.
   --cache-directory &lt;file cache directory&gt;          Add a cache directory.
   --recurse-subdirectories                          Process input files in all subdirectories.
+  --host-only                                       Download only the host program (i.e. dotnet) that lldb needs for loading coredumps.
   --symbols                                         Download the symbol files (.pdb, .dbg, .dwarf).
   --modules                                         Download the module files (.dll, .so, .dylib).
   --debugging                                       Download the special debugging modules (DAC, DBI, SOS).

--- a/src/dotnet-symbol/README.md
+++ b/src/dotnet-symbol/README.md
@@ -14,6 +14,7 @@ This tool can download all the files needed for debugging (symbols, modules, SOS
       --authenticated-server-path <pat> <server path>   Add a http PAT authenticated server path.
       --cache-directory <file cache directory>          Add a cache directory.
       --recurse-subdirectories                          Process input files in all subdirectories.
+      --host-only                                       Download only the host program (i.e. dotnet) that lldb needs for loading coredumps.
       --symbols                                         Download the symbol files (.pdb, .dbg, .dwarf).
       --modules                                         Download the module files (.dll, .so, .dylib).
       --debugging                                       Download the special debugging modules (DAC, DBI, SOS).
@@ -24,23 +25,31 @@ This tool can download all the files needed for debugging (symbols, modules, SOS
 
 ## Install ##
 
-This is a dotnet global tool "extension" supported only in [.NET Core 2.1](https://www.microsoft.com/net/download/). The latest version of the downloader can be installed with the following command. Make sure you are not in any project directory with a NuGet.Config that doesn't include nuget.org as a source. See the Notes section about any errors. 
+This is a dotnet global tool "extension" supported only by [.NET Core 2.1](https://www.microsoft.com/net/download/) or greater. The latest version of the downloader can be installed with the following command. Make sure you are not in any project directory with a NuGet.Config that doesn't include nuget.org as a source. See the Notes section about any errors. 
 
     dotnet tool install -g dotnet-symbol
+
+If you already have dotnet-symbol installed you can update it with:
+
+    dotnet tool update -g dotnet-symbol
 
 ## Examples ##
 
 This will attempt to download all the modules, symbols and SOS/DAC files needed to debug the core dump including the managed assemblies and their PDBs if Linux/ELF core dump or Windows minidump:
 
-    dotnet symbol coredump.4507
+    dotnet-symbol coredump.4507
+
+This downloads just the host program needed to load a core dump on Linux or macOS under lldb. SOS under lldb can download the rest of the symbols and modules needed on demand or with the "loadsymbols" command. See [debugging coredumps](https://github.com/dotnet/diagnostics/blob/master/documentation/debugging-coredump.md) for more details.
+
+    dotnet-symbol --host-only coredump.4507
 
 To download the symbol files for a specific assembly:
 
-    dotnet symbol --symbols --cache-directory c:\temp\symcache --server-path http://symweb --output c:\temp\symout System.Threading.dll
+    dotnet-symbol --symbols --cache-directory c:\temp\symcache --server-path http://symweb --output c:\temp\symout System.Threading.dll
 
 Downloads all the symbol files for the shared runtime:
 
-    dotnet symbol --symbols --output /tmp/symbols /usr/share/dotnet/shared/Microsoft.NETCore.App/2.0.3/*
+    dotnet-symbol --symbols --output /tmp/symbols /usr/share/dotnet/shared/Microsoft.NETCore.App/2.0.3/*
 
 After the symbols are downloaded to `/tmp/symbols` they can be copied back to the above runtime directory so the native debuggers like lldb or gdb can find them, but the copy needs to be superuser:
 
@@ -48,7 +57,7 @@ After the symbols are downloaded to `/tmp/symbols` they can be copied back to th
 
 To verify a symbol package on a local VSTS symbol server:
 
-    dotnet symbol --authenticated-server-path x349x9dfkdx33333livjit4wcvaiwc3v4wjyvnq https://mikemvsts.artifacts.visualstudio.com/defaultcollection/_apis/Symbol/symsrv coredump.45634
+    dotnet-symbol --authenticated-server-path x349x9dfkdx33333livjit4wcvaiwc3v4wjyvnq https://mikemvsts.artifacts.visualstudio.com/defaultcollection/_apis/Symbol/symsrv coredump.45634
 
 ## Notes ##
 


### PR DESCRIPTION
Added the --host-only option that downloads the host program usually "dotnet"
or "apphost" renamed to the program/project name for self-contained apps.