### PR TITLE
Increase macOS dump command limit

### DIFF
--- a/src/Microsoft.FileFormats/MachO/MachOStructures.cs
+++ b/src/Microsoft.FileFormats/MachO/MachOStructures.cs
@@ -88,7 +88,7 @@ namespace Microsoft.FileFormats.MachO
             get
             {
                 return new ValidationRule("Mach Header NumberCommands is unreasonable",
-                                          () => NumberCommands <= 1000);
+                                          () => NumberCommands <= 10000);
             }
         }
         #endregion

--- a/src/Microsoft.FileFormats/PE/PEFile.cs
+++ b/src/Microsoft.FileFormats/PE/PEFile.cs
@@ -88,7 +88,7 @@ namespace Microsoft.FileFormats.PE
                         }
                     }
                 }
-                catch (InvalidVirtualAddressException)
+                catch (Exception ex) when (ex is InvalidVirtualAddressException || ex is BadInputFormatException)
                 {
                 }
             }

--- a/src/Microsoft.SymbolStore/SymbolStores/CacheSymbolStore.cs
+++ b/src/Microsoft.SymbolStore/SymbolStores/CacheSymbolStore.cs
@@ -62,14 +62,14 @@ namespace Microsoft.SymbolStore.SymbolStores
         {
             if (obj is CacheSymbolStore store)
             {
-                return CacheDirectory.Equals(store.CacheDirectory);
+                return IsPathEqual(CacheDirectory, store.CacheDirectory);
             }
             return false;
         }
 
         public override int GetHashCode()
         {
-            return CacheDirectory.GetHashCode();
+            return HashPath(CacheDirectory);
         }
 
         public override string ToString()

--- a/src/Microsoft.SymbolStore/SymbolStores/DirectorySymbolStore.cs
+++ b/src/Microsoft.SymbolStore/SymbolStores/DirectorySymbolStore.cs
@@ -72,14 +72,14 @@ namespace SOS
         {
             if (obj is DirectorySymbolStore store)
             {
-                return Directory.Equals(store.Directory);
+                return IsPathEqual(Directory, store.Directory);
             }
             return false;
         }
 
         public override int GetHashCode()
         {
-            return Directory.GetHashCode();
+            return HashPath(Directory);
         }
 
         public override string ToString()

--- a/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs
+++ b/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs
@@ -29,6 +29,25 @@ namespace Microsoft.SymbolStore.SymbolStores
         public Uri Uri { get; }
 
         /// <summary>
+        /// Get or set the request timeout. Default 4 minutes.
+        /// </summary>
+        public TimeSpan Timeout
+        {
+            get 
+            { 
+                return _client.Timeout;
+            }
+            set 
+            { 
+                _client.Timeout = value; 
+                if (_authenticatedClient != null)
+                {
+                    _authenticatedClient.Timeout = value;
+                }
+            }
+        }
+
+        /// <summary>
         /// Create an instance of a http symbol store
         /// </summary>
         /// <param name="backingStore">next symbol store or null</param>
@@ -85,7 +104,7 @@ namespace Microsoft.SymbolStore.SymbolStores
                 string checksumHeader = string.Join(";", key.PdbChecksums);
                 HttpClient client = _authenticatedClient ?? _client;
                 Tracer.Information($"SymbolChecksum: {checksumHeader}");
-                _client.DefaultRequestHeaders.Add("SymbolChecksum", checksumHeader);
+                client.DefaultRequestHeaders.Add("SymbolChecksum", checksumHeader);
             }
 
             Stream stream = await GetFileStream(uri, token);

--- a/src/Microsoft.SymbolStore/SymbolStores/SymbolStore.cs
+++ b/src/Microsoft.SymbolStore/SymbolStores/SymbolStore.cs
@@ -4,6 +4,7 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.SymbolStore.SymbolStores
 {
@@ -79,6 +80,31 @@ namespace Microsoft.SymbolStore.SymbolStores
             {
                 BackingStore.Dispose();
             }
+        }
+
+        /// <summary>
+        /// Compares two file paths using OS specific casing.
+        /// </summary>
+        internal static bool IsPathEqual(string path1, string path2)
+        {
+#if !NET45
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) 
+            {
+                return string.Equals(path1, path2);
+            }
+#endif
+            return StringComparer.OrdinalIgnoreCase.Equals(path1, path2);
+        }
+
+        internal static int HashPath(string path)
+        {
+#if !NET45
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) 
+            {
+                return path.GetHashCode();
+            }
+#endif
+            return StringComparer.OrdinalIgnoreCase.GetHashCode(path);
         }
     }
 }


### PR DESCRIPTION
Some macOS dumps were failing becase they had > 1000 commands.

Fixed the cache and directory symbol store IsEqual/GetHashCode functions
to do case-insenstive compare/hashes on Windows.

Add Timeout property on http symbol store for slower networks