### PR TITLE
Fix URI double escaping problem

### DIFF
--- a/src/Microsoft.SymbolStore/KeyGenerators/KeyGenerator.cs
+++ b/src/Microsoft.SymbolStore/KeyGenerators/KeyGenerator.cs
@@ -99,7 +99,7 @@ namespace Microsoft.SymbolStore.KeyGenerators
         /// <returns>key</returns>
         protected static SymbolStoreKey BuildKey(string path, string id, bool clrSpecialFile = false, IEnumerable<PdbChecksum> pdbChecksums = null)
         {
-            string file = Uri.EscapeDataString(GetFileName(path).ToLowerInvariant());
+            string file = GetFileName(path).ToLowerInvariant();
             return BuildKey(path, null, id, file, clrSpecialFile, pdbChecksums);
         }
 
@@ -114,7 +114,7 @@ namespace Microsoft.SymbolStore.KeyGenerators
         /// <returns>key</returns>
         protected static SymbolStoreKey BuildKey(string path, string prefix, byte[] id, bool clrSpecialFile = false, IEnumerable<PdbChecksum> pdbChecksums = null)
         {
-            string file = Uri.EscapeDataString(GetFileName(path).ToLowerInvariant());
+            string file = GetFileName(path).ToLowerInvariant();
             return BuildKey(path, prefix, id, file, clrSpecialFile, pdbChecksums);
         }
 

--- a/src/Microsoft.SymbolStore/SymbolStoreKey.cs
+++ b/src/Microsoft.SymbolStore/SymbolStoreKey.cs
@@ -4,6 +4,7 @@ using Microsoft.FileFormats.PE;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 
 namespace Microsoft.SymbolStore
@@ -82,6 +83,8 @@ namespace Microsoft.SymbolStore
             return string.Equals(Index, right.Index);
         }
 
+        private static HashSet<char> s_invalidChars = new HashSet<char>(Path.GetInvalidFileNameChars());
+
         /// <summary>
         /// Validates a symbol index.
         ///
@@ -104,7 +107,7 @@ namespace Microsoft.SymbolStore
                     if (char.IsLetterOrDigit(c)) {
                         continue;
                     }
-                    if (c == '_' || c == '-' || c == '.' || c == '%') {
+                    if (!s_invalidChars.Contains(c)) {
                         continue;
                     }
                     return false;

--- a/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs
+++ b/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs
@@ -121,7 +121,7 @@ namespace Microsoft.SymbolStore.SymbolStores
 
         protected Uri GetRequestUri(string index)
         {
-            if (!Uri.TryCreate(Uri, Uri.EscapeUriString(index), out Uri requestUri))
+            if (!Uri.TryCreate(Uri, Uri.EscapeDataString(index), out Uri requestUri))
             {
                 throw new ArgumentException(nameof(index));
             }

--- a/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs
+++ b/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs
@@ -121,7 +121,7 @@ namespace Microsoft.SymbolStore.SymbolStores
 
         protected Uri GetRequestUri(string index)
         {
-            if (!Uri.TryCreate(Uri, index, out Uri requestUri))
+            if (!Uri.TryCreate(Uri, Uri.EscapeUriString(index), out Uri requestUri))
             {
                 throw new ArgumentException(nameof(index));
             }
@@ -163,7 +163,7 @@ namespace Microsoft.SymbolStore.SymbolStores
                     MarkClientFailure();
                 }
 
-                string message = string.Format("HttpSymbolStore: {0} {1} '{2}'", (int)response.StatusCode, response.ReasonPhrase, requestUri);
+                string message = string.Format("HttpSymbolStore: {0} {1} '{2}'", (int)response.StatusCode, response.ReasonPhrase, requestUri.AbsoluteUri);
                 if (!retryable || response.StatusCode == HttpStatusCode.NotFound)
                 {
                     Tracer.Error(message);
@@ -177,7 +177,7 @@ namespace Microsoft.SymbolStore.SymbolStores
             }
             catch (HttpRequestException ex)
             {
-                Tracer.Error("HttpSymbolStore: {0} '{1}'", ex.Message, requestUri);
+                Tracer.Error("HttpSymbolStore: {0} '{1}'", ex.Message, requestUri.AbsoluteUri);
                 MarkClientFailure();
             }
             return null;


### PR DESCRIPTION
This change moves the URI escaping from where we build the indexes (KeyGenerator.cs) to the http symbol store.  This is so the symbol uploader uses the un-escaped index and the downloader escapes the URI before it gets sent on the network.

The Edge Engineering team uses the SymUploader utility to upload symbol files with blanks and windbg couldn't download them.