### PR TITLE
Add cross-OS DAC to ELF key generator 

### DIFF
--- a/src/Microsoft.SymbolStore.UnitTests/KeyGeneratorTests.cs
+++ b/src/Microsoft.SymbolStore.UnitTests/KeyGeneratorTests.cs
@@ -94,8 +94,16 @@ namespace Microsoft.SymbolStore.Tests
 
                 Dictionary<string, SymbolStoreKey> clrKeys = generator.GetKeys(KeyTypeFlags.ClrKeys).ToDictionary((key) => key.Index);
                 Assert.True(clrKeys.ContainsKey("libmscordaccore.so/elf-buildid-coreclr-ef8f58a0b402d11c68f78342ef4fcc7d23798d4c/libmscordaccore.so"));
+                Assert.True(clrKeys.ContainsKey("libmscordbi.so/elf-buildid-coreclr-ef8f58a0b402d11c68f78342ef4fcc7d23798d4c/libmscordbi.so"));
+                Assert.True(clrKeys.ContainsKey("mscordaccore.dll/elf-buildid-coreclr-ef8f58a0b402d11c68f78342ef4fcc7d23798d4c/mscordaccore.dll"));
                 Assert.True(clrKeys.ContainsKey("libsos.so/elf-buildid-coreclr-ef8f58a0b402d11c68f78342ef4fcc7d23798d4c/libsos.so"));
                 Assert.True(clrKeys.ContainsKey("sos.netcore.dll/elf-buildid-coreclr-ef8f58a0b402d11c68f78342ef4fcc7d23798d4c/sos.netcore.dll"));
+
+                Dictionary<string, SymbolStoreKey> dacdbiKeys = generator.GetKeys(KeyTypeFlags.DacDbiKeys).ToDictionary((key) => key.Index);
+                Assert.True(dacdbiKeys.ContainsKey("libmscordaccore.so/elf-buildid-coreclr-ef8f58a0b402d11c68f78342ef4fcc7d23798d4c/libmscordaccore.so"));
+                Assert.True(dacdbiKeys.ContainsKey("libmscordbi.so/elf-buildid-coreclr-ef8f58a0b402d11c68f78342ef4fcc7d23798d4c/libmscordbi.so"));
+                Assert.False(dacdbiKeys.ContainsKey("libsos.so/elf-buildid-coreclr-ef8f58a0b402d11c68f78342ef4fcc7d23798d4c/libsos.so"));
+                Assert.False(dacdbiKeys.ContainsKey("sos.netcore.dll/elf-buildid-coreclr-ef8f58a0b402d11c68f78342ef4fcc7d23798d4c/sos.netcore.dll"));
             }
 
             using (Stream stream = TestUtilities.OpenCompressedFile("TestBinaries/libcoreclrtraceptprovider.so.dbg.gz"))
@@ -131,6 +139,7 @@ namespace Microsoft.SymbolStore.Tests
                 Dictionary<string, SymbolStoreKey> identityKeys = generator.GetKeys(KeyTypeFlags.IdentityKey).ToDictionary((key) => key.Index);
                 Dictionary<string, SymbolStoreKey> symbolKeys = generator.GetKeys(KeyTypeFlags.SymbolKey).ToDictionary((key) => key.Index);
                 Dictionary<string, SymbolStoreKey> clrKeys = generator.GetKeys(KeyTypeFlags.ClrKeys).ToDictionary((key) => key.Index);
+                Dictionary<string, SymbolStoreKey> dacdbiKeys = generator.GetKeys(KeyTypeFlags.DacDbiKeys).ToDictionary((key) => key.Index);
 
                 // System.Native.dylib
                 Assert.True(identityKeys.ContainsKey("system.native.dylib/mach-uuid-f7c77509e13a3da18099a2b97e90fade/system.native.dylib"));
@@ -141,8 +150,14 @@ namespace Microsoft.SymbolStore.Tests
                 Assert.True(symbolKeys.ContainsKey("_.dwarf/mach-uuid-sym-3e0f66c5527338b18141e9d63b8ab415/_.dwarf"));
 
                 Assert.True(clrKeys.ContainsKey("libmscordaccore.dylib/mach-uuid-coreclr-3e0f66c5527338b18141e9d63b8ab415/libmscordaccore.dylib"));
+                Assert.True(clrKeys.ContainsKey("libmscordbi.dylib/mach-uuid-coreclr-3e0f66c5527338b18141e9d63b8ab415/libmscordbi.dylib"));
                 Assert.True(clrKeys.ContainsKey("libsos.dylib/mach-uuid-coreclr-3e0f66c5527338b18141e9d63b8ab415/libsos.dylib"));
                 Assert.True(clrKeys.ContainsKey("sos.netcore.dll/mach-uuid-coreclr-3e0f66c5527338b18141e9d63b8ab415/sos.netcore.dll"));
+
+                Assert.True(dacdbiKeys.ContainsKey("libmscordaccore.dylib/mach-uuid-coreclr-3e0f66c5527338b18141e9d63b8ab415/libmscordaccore.dylib"));
+                Assert.True(dacdbiKeys.ContainsKey("libmscordbi.dylib/mach-uuid-coreclr-3e0f66c5527338b18141e9d63b8ab415/libmscordbi.dylib"));
+                Assert.False(dacdbiKeys.ContainsKey("libsos.dylib/mach-uuid-coreclr-3e0f66c5527338b18141e9d63b8ab415/libsos.dylib"));
+                Assert.False(dacdbiKeys.ContainsKey("sos.netcore.dll/mach-uuid-coreclr-3e0f66c5527338b18141e9d63b8ab415/sos.netcore.dll"));
             }
         }
 
@@ -302,8 +317,15 @@ namespace Microsoft.SymbolStore.Tests
 
                 Dictionary<string, SymbolStoreKey> clrKeys = generator.GetKeys(KeyTypeFlags.ClrKeys).ToDictionary((key) => key.Index);
                 Assert.True(clrKeys.ContainsKey("mscordaccore.dll/595ebcd5538000/mscordaccore.dll"));
+                Assert.True(clrKeys.ContainsKey("mscordbi.dll/595ebcd5538000/mscordbi.dll"));
                 Assert.True(clrKeys.ContainsKey("sos.dll/595ebcd5538000/sos.dll"));
                 Assert.True(clrKeys.ContainsKey("sos.netcore.dll/595ebcd5538000/sos.netcore.dll"));
+
+                Dictionary<string, SymbolStoreKey> dacdbiKeys = generator.GetKeys(KeyTypeFlags.DacDbiKeys).ToDictionary((key) => key.Index);
+                Assert.True(dacdbiKeys.ContainsKey("mscordaccore.dll/595ebcd5538000/mscordaccore.dll"));
+                Assert.True(dacdbiKeys.ContainsKey("mscordbi.dll/595ebcd5538000/mscordbi.dll"));
+                Assert.False(dacdbiKeys.ContainsKey("sos.dll/595ebcd5538000/sos.dll"));
+                Assert.False(dacdbiKeys.ContainsKey("sos.netcore.dll/595ebcd5538000/sos.netcore.dll"));
             }
         }
 

--- a/src/Microsoft.SymbolStore/KeyGenerators/ELFFileKeyGenerator.cs
+++ b/src/Microsoft.SymbolStore/KeyGenerators/ELFFileKeyGenerator.cs
@@ -125,7 +125,7 @@ namespace Microsoft.SymbolStore.KeyGenerators
                     /// Creates all the special CLR keys if the path is the coreclr module for this platform
                     if (GetFileName(path) == CoreClrFileName)
                     {
-                        foreach (string specialFileName in (flags & KeyTypeFlags.DacDbiKeys) != 0 ? s_dacdbiSpecialFiles : s_coreClrSpecialFiles)
+                        foreach (string specialFileName in (flags & KeyTypeFlags.ClrKeys) != 0 ? s_coreClrSpecialFiles : s_dacdbiSpecialFiles)
                         {
                             yield return BuildKey(specialFileName, CoreClrPrefix, buildId);
                         }

--- a/src/Microsoft.SymbolStore/KeyGenerators/ELFFileKeyGenerator.cs
+++ b/src/Microsoft.SymbolStore/KeyGenerators/ELFFileKeyGenerator.cs
@@ -11,17 +11,20 @@ namespace Microsoft.SymbolStore.KeyGenerators
 {
     public class ELFFileKeyGenerator : KeyGenerator
     {
-        /// <summary>
-        /// Symbol file extensions. The first one is the default symbol file extension used by .NET Core.
-        /// </summary>
-        private static readonly string[] SymbolFileExtensions = { ".dbg", ".debug" };
-
         private const string IdentityPrefix = "elf-buildid";
         private const string SymbolPrefix = "elf-buildid-sym";
         private const string CoreClrPrefix = "elf-buildid-coreclr";
         private const string CoreClrFileName = "libcoreclr.so";
 
-        private static HashSet<string> s_coreClrSpecialFiles = new HashSet<string>(new string[] { "libmscordaccore.so", "libmscordbi.so", "libsos.so", "SOS.NETCore.dll" });
+        /// <summary>
+        /// Symbol file extensions. The first one is the default symbol file extension used by .NET Core.
+        /// </summary>
+        private static readonly string[] s_symbolFileExtensions = { ".dbg", ".debug" };
+        
+        /// <summary>
+        /// List of special clr files that are also indexed with libcoreclr.so's key.
+        /// </summary>
+        private static HashSet<string> s_coreClrSpecialFiles = new HashSet<string>(new string[] { "libmscordaccore.so", "libmscordbi.so", "mscordaccore.dll", "libsos.so", "SOS.NETCore.dll" });
 
         private readonly ELFFile _elfFile;
         private readonly string _path;
@@ -51,7 +54,7 @@ namespace Microsoft.SymbolStore.KeyGenerators
                 byte[] buildId = _elfFile.BuildID;
                 if (buildId != null && buildId.Length == 20)
                 {
-                    bool symbolFile = Array.IndexOf(SymbolFileExtensions, Path.GetExtension(_path)) != -1;
+                    bool symbolFile = Array.IndexOf(s_symbolFileExtensions, Path.GetExtension(_path)) != -1;
                     string symbolFileName = GetSymbolFileName();
                     foreach (SymbolStoreKey key in GetKeys(flags, _path, buildId, symbolFile, symbolFileName))
                     {
@@ -108,7 +111,7 @@ namespace Microsoft.SymbolStore.KeyGenerators
                 {
                     if (string.IsNullOrEmpty(symbolFileName))
                     {
-                        symbolFileName = path + SymbolFileExtensions[0];
+                        symbolFileName = path + s_symbolFileExtensions[0];
                     }
                     yield return BuildKey(symbolFileName, SymbolPrefix, buildId, "_.debug");
                 }

--- a/src/Microsoft.SymbolStore/KeyGenerators/KeyGenerator.cs
+++ b/src/Microsoft.SymbolStore/KeyGenerators/KeyGenerator.cs
@@ -47,7 +47,13 @@ namespace Microsoft.SymbolStore.KeyGenerators
         /// module key (usually "dotnet") and an "apphost" symbol index using 
         /// the exe or main module's build id for self-contained apps.
         /// </summary>
-        HostKeys = 0x10
+        HostKeys = 0x10,
+
+        /// <summary>
+        /// Return only the DAC (including any cross-OS DACs) and DBI module 
+        /// keys. Does not including any SOS binaries.
+        /// </summary>
+        DacDbiKeys = 0x20
     }
 
     /// <summary>

--- a/src/Microsoft.SymbolStore/KeyGenerators/MachOKeyGenerator.cs
+++ b/src/Microsoft.SymbolStore/KeyGenerators/MachOKeyGenerator.cs
@@ -122,7 +122,7 @@ namespace Microsoft.SymbolStore.KeyGenerators
                     /// Creates all the special CLR keys if the path is the coreclr module for this platform
                     if (GetFileName(path) == CoreClrFileName)
                     {
-                        foreach (string specialFileName in (flags & KeyTypeFlags.DacDbiKeys) != 0 ? s_dacdbiSpecialFiles : s_coreClrSpecialFiles)
+                        foreach (string specialFileName in (flags & KeyTypeFlags.ClrKeys) != 0 ? s_coreClrSpecialFiles : s_dacdbiSpecialFiles)
                         {
                             yield return BuildKey(specialFileName, CoreClrPrefix, uuid);
                         }

--- a/src/Microsoft.SymbolStore/KeyGenerators/MachOKeyGenerator.cs
+++ b/src/Microsoft.SymbolStore/KeyGenerators/MachOKeyGenerator.cs
@@ -4,7 +4,7 @@ using Microsoft.FileFormats;
 using Microsoft.FileFormats.MachO;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
+using System.Linq;
 
 namespace Microsoft.SymbolStore.KeyGenerators
 {
@@ -20,7 +20,11 @@ namespace Microsoft.SymbolStore.KeyGenerators
         private const string CoreClrPrefix = "mach-uuid-coreclr";
         private const string CoreClrFileName = "libcoreclr.dylib";
 
-        private static HashSet<string> s_coreClrSpecialFiles = new HashSet<string>(new string[] { "libmscordaccore.dylib", "libmscordbi.dylib", "libsos.dylib", "SOS.NETCore.dll" });
+        private static readonly string[] s_specialFiles = new string[] { "libmscordaccore.dylib", "libmscordbi.dylib" };
+        private static readonly string[] s_sosSpecialFiles = new string[] { "libsos.dylib", "SOS.NETCore.dll" };
+
+        private static readonly HashSet<string> s_coreClrSpecialFiles = new HashSet<string>(s_specialFiles.Concat(s_sosSpecialFiles));
+        private static readonly HashSet<string> s_dacdbiSpecialFiles = new HashSet<string>(s_specialFiles);
 
         private readonly MachOFile _machoFile;
         private readonly string _path;
@@ -113,12 +117,12 @@ namespace Microsoft.SymbolStore.KeyGenerators
                     }
                     yield return BuildKey(symbolFileName, SymbolPrefix, uuid, "_.dwarf");
                 }
-                if ((flags & KeyTypeFlags.ClrKeys) != 0)
+                if ((flags & (KeyTypeFlags.ClrKeys | KeyTypeFlags.DacDbiKeys)) != 0)
                 {
                     /// Creates all the special CLR keys if the path is the coreclr module for this platform
                     if (GetFileName(path) == CoreClrFileName)
                     {
-                        foreach (string specialFileName in s_coreClrSpecialFiles)
+                        foreach (string specialFileName in (flags & KeyTypeFlags.DacDbiKeys) != 0 ? s_dacdbiSpecialFiles : s_coreClrSpecialFiles)
                         {
                             yield return BuildKey(specialFileName, CoreClrPrefix, uuid);
                         }

--- a/src/Microsoft.SymbolStore/KeyGenerators/PEFileKeyGenerator.cs
+++ b/src/Microsoft.SymbolStore/KeyGenerators/PEFileKeyGenerator.cs
@@ -105,7 +105,7 @@ namespace Microsoft.SymbolStore.KeyGenerators
 
         private IEnumerable<string> GetSpecialFiles(KeyTypeFlags flags)
         {
-            var specialFiles = new List<string>((flags & KeyTypeFlags.DacDbiKeys) != 0 ? s_dacdbiSpecialFiles : s_coreClrSpecialFiles);
+            var specialFiles = new List<string>((flags & KeyTypeFlags.ClrKeys) != 0 ? s_coreClrSpecialFiles : s_dacdbiSpecialFiles);
 
             VsFixedFileInfo fileVersion = _peFile.VersionInfo;
             if (fileVersion != null)
@@ -160,7 +160,7 @@ namespace Microsoft.SymbolStore.KeyGenerators
                             }
                         }
 
-                        foreach (string name in (flags & KeyTypeFlags.DacDbiKeys) != 0 ? s_daclongNameBinaryPrefixes : s_longNameBinaryPrefixes)
+                        foreach (string name in (flags & KeyTypeFlags.ClrKeys) != 0 ? s_longNameBinaryPrefixes : s_daclongNameBinaryPrefixes)
                         {
                             // The name prefixes include the trailing "_".
                             string longName = string.Format("{0}{1}_{2}_{3}.{4}.{5}.{6:00}{7}.dll",


### PR DESCRIPTION
Issue: #181

Add DacDbiKeys key generator flag. Allows SOS to remove some really hacky filtering code.