### PR TITLE
Treat relocatable ELF file as valid

### DIFF
--- a/src/Microsoft.SymbolStore/KeyGenerators/ELFFileKeyGenerator.cs
+++ b/src/Microsoft.SymbolStore/KeyGenerators/ELFFileKeyGenerator.cs
@@ -49,7 +49,7 @@ namespace Microsoft.SymbolStore.KeyGenerators
         public override bool IsValid()
         {
             return _elfFile.IsValid() &&
-                (_elfFile.Header.Type == ELFHeaderType.Executable || _elfFile.Header.Type == ELFHeaderType.Shared);
+                (_elfFile.Header.Type == ELFHeaderType.Executable || _elfFile.Header.Type == ELFHeaderType.Shared || _elfFile.Header.Type == ELFHeaderType.Relocatable);
         }
 
         public override IEnumerable<SymbolStoreKey> GetKeys(KeyTypeFlags flags)


### PR DESCRIPTION
Due to KeyGenerator check relocatable ELF were rejected as Unknown.

