### PR TITLE
Change PrpsInfo to GnuBuildId

### DIFF
--- a/docs/specs/SSQP_Key_Conventions.md
+++ b/docs/specs/SSQP_Key_Conventions.md
@@ -65,7 +65,7 @@ Example:
 
 ### ELF-buildid
 
-This applies to any ELF format files that have been stripped of debugging information, commonly using the .so suffix or no suffix. The key is computed by reading the 20 byte sequence of the ELF Note section that is named “GNU” and that has note type PRPSINFO (3). If byte sequence is smaller than 20 bytes, bytes of value 0x00 should be added until the byte sequence is 20 bytes long. The final key is formatted:
+This applies to any ELF format files that have been stripped of debugging information, commonly using the .so suffix or no suffix. The key is computed by reading the 20 byte sequence of the ELF Note section that is named “GNU” and that has note type GNU Build Id (3). If byte sequence is smaller than 20 bytes, bytes of value 0x00 should be added until the byte sequence is 20 bytes long. The final key is formatted:
 
 `<file_name>/elf-buildid-<note_byte_sequence>/<file_name>`
 
@@ -80,7 +80,7 @@ Example:
 
 ### ELF-buildid-sym
 
-This applies to any ELF format files that have not been stripped of debugging information, commonly ending in ‘.so.dbg’ or ‘.dbg’. The key is computed by reading the 20 byte sequence of the ELF Note section that is named “GNU” and that has note type PRPSINFO (3). If byte sequence is smaller than 20 bytes, bytes of value 0x00 should be added until the byte sequence is 20 bytes long. The file name is not used in the index because there are cases where all we have is the build id. The final key is formatted:
+This applies to any ELF format files that have not been stripped of debugging information, commonly ending in ‘.so.dbg’ or ‘.dbg’. The key is computed by reading the 20 byte sequence of the ELF Note section that is named “GNU” and that has note type GNU Build Id (3). If byte sequence is smaller than 20 bytes, bytes of value 0x00 should be added until the byte sequence is 20 bytes long. The file name is not used in the index because there are cases where all we have is the build id. The final key is formatted:
 
 `_.debug/elf-buildid-sym-<note_byte_sequence>/_.debug`
 

--- a/src/Microsoft.FileFormats/ELF/ELFFile.cs
+++ b/src/Microsoft.FileFormats/ELF/ELFFile.cs
@@ -198,7 +198,7 @@ namespace Microsoft.FileFormats.ELF
                 foreach (ELFNote note in noteList.Notes)
                 {
                     ELFNoteType type = note.Header.Type;
-                    if (type == ELFNoteType.PrpsInfo && note.Name.Equals("GNU"))
+                    if (type == ELFNoteType.GnuBuildId && note.Name.Equals("GNU"))
                     {
                         return note.Contents.Read(0, (uint)note.Contents.Length);
                     }

--- a/src/Microsoft.FileFormats/ELF/ELFNoteHeader.cs
+++ b/src/Microsoft.FileFormats/ELF/ELFNoteHeader.cs
@@ -11,7 +11,8 @@ namespace Microsoft.FileFormats.ELF
 {
     public enum ELFNoteType
     {
-        PrpsInfo = 3,
+        PrpsInfo = 3, // NT_PRPSINFO
+        GnuBuildId = 3, // NT_GNU_BUILD_ID
         File = 0x46494c45 // "FILE" in ascii
     }
 


### PR DESCRIPTION
The ELF note headers give name "GNU" and type 3 (NT_GNU_BUILD_ID) for a build ID note, not PRPSINFO.