### PR TITLE
Revert System.Reflection.Metadata version for net45 framework

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,7 +14,6 @@
     <MicrosoftNetCompilersVersion>3.0.0</MicrosoftNetCompilersVersion>
     <!-- CoreFX -->
     <SystemReflectionMetadataVersion>1.8.1</SystemReflectionMetadataVersion>
-    <SystemCollectionsImmutableVersion>1.7.1</SystemCollectionsImmutableVersion>
   </PropertyGroup>
   <PropertyGroup>
     <RestoreSources>

--- a/src/Microsoft.FileFormats/Microsoft.FileFormats.csproj
+++ b/src/Microsoft.FileFormats/Microsoft.FileFormats.csproj
@@ -1,7 +1,7 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <NoWarn>;1591;1701</NoWarn>
     <IsPackable>true</IsPackable>
     <Description>File format readers</Description>

--- a/src/Microsoft.SymbolStore/Microsoft.SymbolStore.csproj
+++ b/src/Microsoft.SymbolStore/Microsoft.SymbolStore.csproj
@@ -12,14 +12,15 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
+    <PackageReference Condition="'$(TargetFramework)' != 'net45'" Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
+    <PackageReference Condition="'$(TargetFramework)' == 'net45'" Include="System.Reflection.Metadata" Version="1.6.0" />
   </ItemGroup>
   
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.FileFormats\Microsoft.FileFormats.csproj" />
   </ItemGroup>
   
-  <ItemGroup Condition="'$(TargetFramework)'=='net45'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Upgrading S.R.M to 1.8.7 (from 1.6.0) broke the symuploader net45 framework build. We need to leave the "net45" builds alone as far as dependency versions.