### PR TITLE
Add --timeout dotnet-symbol command line option and better "Not Found" error message

### DIFF
--- a/src/Microsoft.SymbolStore/KeyGenerators/ELFFileKeyGenerator.cs
+++ b/src/Microsoft.SymbolStore/KeyGenerators/ELFFileKeyGenerator.cs
@@ -65,7 +65,11 @@ namespace Microsoft.SymbolStore.KeyGenerators
                     {
                         symbolFile = Array.Exists(_elfFile.Sections, section => (section.Name.StartsWith(".debug_info") || section.Name.StartsWith(".zdebug_info")));
                     }
-                    catch (Exception ex) when (ex is InvalidVirtualAddressException || ex is BadInputFormatException)
+                    catch (Exception ex) when 
+                       (ex is InvalidVirtualAddressException ||
+                        ex is ArgumentOutOfRangeException ||
+                        ex is IndexOutOfRangeException ||
+                        ex is BadInputFormatException)
                     {
                         // This could occur when trying to read sections for an ELF image grabbed from a core dump
                         // In that case, fallback to checking the file extension
@@ -171,7 +175,12 @@ namespace Microsoft.SymbolStore.KeyGenerators
                     return section.Contents.Read<string>(0);
                 }
             }
-            catch (Exception ex) when (ex is InvalidVirtualAddressException || ex is BadInputFormatException)
+            catch (Exception ex) when 
+               (ex is InvalidVirtualAddressException ||
+                ex is ArgumentOutOfRangeException ||
+                ex is IndexOutOfRangeException ||
+                ex is BadInputFormatException)
+ 
             {
                 Tracer.Verbose("ELF .gnu_debuglink section in {0}: {1}", _path, ex.Message);
             }

--- a/src/Microsoft.SymbolStore/SymbolStores/SymwebSymbolStore.cs
+++ b/src/Microsoft.SymbolStore/SymbolStores/SymwebSymbolStore.cs
@@ -32,7 +32,7 @@ namespace Microsoft.SymbolStore.SymbolStores
                 return file;
             }
             Uri filePtrUri = GetRequestUri(key.IndexPrefix + "file.ptr");
-            Stream filePtrStream = await GetFileStream(filePtrUri, token);
+            Stream filePtrStream = await GetFileStream(key.FullPathName, filePtrUri, token);
             if (filePtrStream != null)
             {
                 using (filePtrStream)

--- a/src/dotnet-symbol/Program.cs
+++ b/src/dotnet-symbol/Program.cs
@@ -108,7 +108,7 @@ namespace dotnet.symbol
                     case "--timeout":
                         if (++i < args.Length)
                         {
-                            int timeoutInMinutes = int.Parse(args[i]);
+                            double timeoutInMinutes = double.Parse(args[i]);
                             program.Timeout = TimeSpan.FromMinutes(timeoutInMinutes);
                         }
                         else 

--- a/src/dotnet-symbol/Program.cs
+++ b/src/dotnet-symbol/Program.cs
@@ -27,6 +27,7 @@ namespace dotnet.symbol
         private readonly List<string> CacheDirectories = new List<string>();
         private readonly List<ServerInfo> SymbolServers = new List<ServerInfo>();
         private string OutputDirectory;
+        private TimeSpan? Timeout;
         private bool Subdirectories;
         private bool Symbols;
         private bool Debugging;
@@ -96,6 +97,16 @@ namespace dotnet.symbol
                         if (++i < args.Length)
                             program.OutputDirectory = args[i];
                         else
+                            goto usage;
+                        break;
+
+                    case "--timeout":
+                        if (++i < args.Length)
+                        {
+                            int timeoutInMinutes = int.Parse(args[i]);
+                            program.Timeout = TimeSpan.FromMinutes(timeoutInMinutes);
+                        }
+                        else 
                             goto usage;
                         break;
 
@@ -221,6 +232,10 @@ namespace dotnet.symbol
                 else
                 {
                     store = new HttpSymbolStore(Tracer, store, server.Uri, server.PersonalAccessToken);
+                }
+                if (Timeout.HasValue && store is HttpSymbolStore http)
+                { 
+                    http.Timeout = Timeout.Value;
                 }
             }
 

--- a/src/dotnet-symbol/Program.cs
+++ b/src/dotnet-symbol/Program.cs
@@ -28,6 +28,7 @@ namespace dotnet.symbol
         private readonly List<ServerInfo> SymbolServers = new List<ServerInfo>();
         private string OutputDirectory;
         private TimeSpan? Timeout;
+        private bool Overwrite;
         private bool Subdirectories;
         private bool Symbols;
         private bool Debugging;
@@ -98,6 +99,10 @@ namespace dotnet.symbol
                             program.OutputDirectory = args[i];
                         else
                             goto usage;
+                        break;
+
+                    case "--overwrite":
+                        program.Overwrite = true;
                         break;
 
                     case "--timeout":
@@ -370,9 +375,9 @@ namespace dotnet.symbol
         {
             stream.Position = 0;
             string destination = Path.Combine(destinationDirectory, Path.GetFileName(fileName.Replace('\\', '/')));
-            if (File.Exists(destination))
+            if (!Overwrite && File.Exists(destination))
             {
-                Tracer.Warning(Resources.FileAlreadyExists, destination);
+                Tracer.WriteLine(Resources.FileAlreadyExists, destination);
             }
             else
             {

--- a/src/dotnet-symbol/Properties/Resources.Designer.cs
+++ b/src/dotnet-symbol/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace dotnet.symbol.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -106,7 +106,7 @@ namespace dotnet.symbol.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Usage: dotnet symbols [options] &lt;FILES&gt;
+        ///   Looks up a localized string similar to Usage: dotnet symbol [options] &lt;FILES&gt;
         ///
         ///Arguments:
         ///  &lt;FILES&gt;   List of files. Can contain wildcards.
@@ -115,7 +115,7 @@ namespace dotnet.symbol.Properties {
         ///  --microsoft-symbol-server                         Add &apos;http://msdl.microsoft.com/download/symbols&apos; symbol server path (default).
         ///  --internal-server                                 Add &apos;http://symweb.corp.microsoft.com&apos; internal symbol server path.
         ///  --server-path &lt;symbol server path&gt;                Add a http server path.
-        ///  --authenticated-server-path &lt;pat&gt; &lt;server path&gt;   Add a http P [rest of string was truncated]&quot;;.
+        ///  --authenticated-server-path &lt;pat&gt; &lt;server path&gt;   Add a http PA [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string UsageOptions {
             get {

--- a/src/dotnet-symbol/Properties/Resources.resx
+++ b/src/dotnet-symbol/Properties/Resources.resx
@@ -144,12 +144,14 @@ Options:
   --server-path &lt;symbol server path&gt;                Add a http server path.
   --authenticated-server-path &lt;pat&gt; &lt;server path&gt;   Add a http PAT authenticated server path.
   --cache-directory &lt;file cache directory&gt;          Add a cache directory.
+  --timeout &lt;minutes&gt;                               Change http timeout in minutes (default: 4).
   --recurse-subdirectories                          Process input files in all subdirectories.
   --host-only                                       Download only the host program (i.e. dotnet) that lldb needs for loading coredumps.
   --symbols                                         Download the symbol files (.pdb, .dbg, .dwarf).
   --modules                                         Download the module files (.dll, .so, .dylib).
   --debugging                                       Download the special debugging modules (DAC, DBI, SOS).
   --windows-pdbs                                    Force the downloading of the Windows PDBs when Portable PDBs are also available.
+  --overwrite                                       Overwrite existing files in output directory.
   -o, --output &lt;output directory&gt;                   Set the output directory. Otherwise, write next to the input file (default).
   -d, --diagnostics                                 Enable diagnostic output.
   -h, --help                                        Show help information.</value>


### PR DESCRIPTION
Make reading section name more bullet proof

Issue: https://github.com/dotnet/symstore/issues/256 and https://github.com/dotnet/symstore/issues/246.