### PR TITLE
Use EscapeUriString instead of EscapeDataString

### DIFF
--- a/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs
+++ b/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs
@@ -119,7 +119,7 @@ namespace Microsoft.SymbolStore.SymbolStores
 
         protected Uri GetRequestUri(string index)
         {
-            if (!Uri.TryCreate(Uri, Uri.EscapeDataString(index), out Uri requestUri))
+            if (!Uri.TryCreate(Uri, Uri.EscapeUriString(index), out Uri requestUri))
             {
                 throw new ArgumentException(nameof(index));
             }


### PR DESCRIPTION
It seems like due to the recent change at the storage side, the escaped `index` component of URL is not working anymore.

#### Before

```sh
$ dotnet symbol --symbols mysinglefilehostapp1 --timeout 20
Downloading from http://msdl.microsoft.com/download/symbols/
ERROR: Not Found: singlefilehost.dbg - 'http://msdl.microsoft.com/download/symbols/_.debug%2Felf-buildid-sym-27997343859af70e0bfc5e50a4d1059b3513a1c4%2F_.debug'
```

http://msdl.microsoft.com/download/symbols/_.debug%2Felf-buildid-sym-27997343859af70e0bfc5e50a4d1059b3513a1c4%2F_.debug is returning 404.

Replacing `%2F` with `/` fixes the issue: http://msdl.microsoft.com/download/symbols/_.debug/elf-buildid-sym-27997343859af70e0bfc5e50a4d1059b3513a1c4/_.debug is valid.

#### After

```sh
$ dotnet symbol --symbols mysinglefilehostapp1 --timeout 20
Downloading from http://msdl.microsoft.com/download/symbols/
Writing: ./singlefilehost.dbg
```

To reproduce it on machine with pre-downloaded symbol, rename `~/.dotnet/symbolcache` directory temporarily to force the re-download (or try it in a new VM).

Fixes https://github.com/dotnet/diagnostics/issues/1978.