### PR TITLE
Fix issue https://github.com/dotnet/symstore/issues/327

### DIFF
--- a/src/Microsoft.FileFormats/MachO/MachOFile.cs
+++ b/src/Microsoft.FileFormats/MachO/MachOFile.cs
@@ -493,7 +493,7 @@ namespace Microsoft.FileFormats.MachO
             NList[] symTable = _symbolTable.Value;
             if (symTable is not null)
             {
-                for (uint i = 0; i < nsyms; i++)
+                for (uint i = 0; i < nsyms && start + i < symTable.Length; i++)
                 {
                     string name = _stringReader.Value.Read<string>(symTable[start + i].StringIndex); 
                     if (name.Length > 0)

--- a/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs
+++ b/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs
@@ -187,7 +187,7 @@ namespace Microsoft.SymbolStore.SymbolStores
             }
             catch (HttpRequestException ex)
             {
-                Tracer.Error("HttpSymbolStore: {0} {1} - '{2}'", ex.Message, fileName, requestUri.AbsoluteUri);
+                Tracer.Error("HttpSymbolStore: {0} '{1}' {2}", fileName, requestUri.AbsoluteUri, ex.ToString());
                 MarkClientFailure();
             }
             return null;


### PR DESCRIPTION
Reworked the symbol lookup code. Needed to fallback to search all symbols if it can find the it in the exported symbols. It always read every symbol name in the old path.