### PR TITLE
Add retry logic to HttpSymbolStore to help make the diagnostics repo tests more reliable

### DIFF
--- a/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs
+++ b/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs
@@ -261,7 +261,6 @@ namespace Microsoft.SymbolStore.SymbolStores
         {
             SocketError.ConnectionReset,
             SocketError.ConnectionAborted,
-            SocketError.ConnectionRefused,
             SocketError.Shutdown,
             SocketError.TimedOut,
             SocketError.TryAgain,


### PR DESCRIPTION
Don't mark permanent failures for some socket errors.  