### PR TITLE
Update retry logic in HttpSymbolStore to check nested inner exceptions

### DIFF
--- a/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs
+++ b/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs
@@ -198,7 +198,7 @@ namespace Microsoft.SymbolStore.SymbolStores
                     Exception innerException = ex.InnerException;
                     while (innerException != null)
                     {
-                        if (ex.InnerException is SocketException se)
+                        if (innerException is SocketException se)
                         {
                             socketError = se.SocketErrorCode;
                             retryable = IsRetryableSocketError(socketError);


### PR DESCRIPTION
I hit an issue where the retry logic introduced in https://github.com/dotnet/symstore/pull/336 was not triggering a retry when expected.  In my scenario, the retryable socket error (`SocketError.ConnectionReset`) is wrapped inside an `IOException` so it's never discovered. This PR updates the retry logic to check all of the inner exceptions for any `SocketException`.

Output of a repro of this issue:
```csharp
HttpSymbolStore: System.Threading.pdb retryable False socketError Success 'https://msdl.microsoft.com/download/symbols/system.threading.pdb/0b2084837920461e848e61a94c16d65cFFFFFFFF/system.threading.pdb' System.Net.Http.HttpRequestException: An error occurred while sending the request.
 ---> System.IO.IOException: Unable to read data from the transport connection: Connection reset by peer.
 ---> System.Net.Sockets.SocketException (104): Connection reset by peer
   --- End of inner exception stack trace ---
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Net.Security.SslStream.EnsureFullTlsFrameAsync[TIOAdapter](TIOAdapter adapter)
   at System.Net.Security.SslStream.ReadAsyncInternal[TIOAdapter](TIOAdapter adapter, Memory`1 buffer)
   at System.Net.Http.HttpConnection.InitialFillAsync(Boolean async)
   at System.Net.Http.HttpConnection.SendAsyncCore(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   --- End of inner exception stack trace ---
   at System.Net.Http.HttpConnection.SendAsyncCore(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.SendWithVersionDetectionAndRetryAsync(HttpRequestMessage request, Boolean async, Boolean doRequestAuth, CancellationToken cancellationToken)
   at System.Net.Http.RedirectHandler.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
   at Microsoft.SymbolStore.SymbolStores.HttpSymbolStore.GetFileStream(String path, Uri requestUri, CancellationToken token)

```