### PR TITLE
Update docker image to the latest schema

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ variables:
 resources:
   containers:
   - container: LinuxContainer
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-latest
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04
 
 stages:
   - stage: build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ variables:
 resources:
   containers:
   - container: LinuxContainer
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-09ca40b-20190520220842
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-latest
 
 stages:
   - stage: build


### PR DESCRIPTION
As a part of https://github.com/dotnet/arcade/issues/10123, we are moving all docker containers to the "latest" tagging schema