### PR TITLE
Pointer layout changes

### DIFF
--- a/src/Microsoft.FileFormats/Pointer.cs
+++ b/src/Microsoft.FileFormats/Pointer.cs
@@ -122,7 +122,7 @@ namespace Microsoft.FileFormats
             return instance.Value;
         }
 
-        public void Initialize(ulong value, PointerLayout layout)
+        internal void Initialize(ulong value, PointerLayout layout)
         {
             Value = value;
             Layout = layout;

--- a/src/Microsoft.FileFormats/TStruct.cs
+++ b/src/Microsoft.FileFormats/TStruct.cs
@@ -142,20 +142,20 @@ namespace Microsoft.FileFormats
         /// The set of defines that can be used to enabled optional fields decorated with the IfAttribute
         /// </param>
         /// <param name="requiredBaseType"></param>
-        /// <returns></returns>
         public static LayoutManager AddReflectionTypes(this LayoutManager layouts, IEnumerable<string> enabledDefines, Type requiredBaseType)
         {
-            layouts.AddLayoutProvider((type, layoutManager) =>
-            {
-                if (!requiredBaseType.GetTypeInfo().IsAssignableFrom(type))
-                {
-                    return null;
-                }
-                return GetTStructLayout(type, layoutManager, enabledDefines);
-            });
-            return layouts;
+            return layouts.AddReflectionTypes(enabledDefines, typeFilter: (type) => requiredBaseType.GetTypeInfo().IsAssignableFrom(type));
         }
 
+        /// <summary>
+        /// Adds support for parsing types filtered by typeFilter from by using reflection to interpret their fields.
+        /// All field types used within these types must also have layouts available from the LayoutManager.
+        /// </summary>
+        /// <param name="layouts"></param>
+        /// <param name="enabledDefines">
+        /// The set of defines that can be used to enabled optional fields decorated with the IfAttribute
+        /// </param>
+        /// <param name="typeFilter">return true if reflection should be used to layout the type</param>
         public static LayoutManager AddReflectionTypes(this LayoutManager layouts, IEnumerable<string> enabledDefines, Func<Type, bool> typeFilter)
         {
             layouts.AddLayoutProvider((type, layoutManager) =>


### PR DESCRIPTION
Delay getting a Pointer's target type layout until the pointer's target is dereferenced to avoid recursion/stack overflow when creating the layout for types that have a field that a Pointer to itself.

This does change some protected fields in the PointerLayout (_storageLayout, _targetLayout) and Pointer (_targetLayout) classes but I think the chances are very low that some one depends on them.

Added LayoutManager.AddReflectionTypes override with a typeFilter that allows duplicated code to be removed from the DCR.