### PR TITLE
Fix ELF build id key generator padding

### DIFF
--- a/src/Microsoft.SymbolStore/KeyGenerators/ELFFileKeyGenerator.cs
+++ b/src/Microsoft.SymbolStore/KeyGenerators/ELFFileKeyGenerator.cs
@@ -190,11 +190,11 @@ namespace Microsoft.SymbolStore.KeyGenerators
         }
 
         /// <summary>
-        /// Extends build-ids of 16 bytes (created by MD5 or UUID build ids) to 20 bytes
+        /// Extends build-ids of 8-20 bytes (created by MD5 or UUID build ids) to 20 bytes with proper padding
         /// using a zero extension
         /// </summary>
-        /// <param name="buildId">Reference to ELF build-id. This build-id maybe extended to 20 bytes</param>
-        /// <returns>symbol store keys</returns>
+        /// <param name="buildId">Reference to ELF build-id. This build-id must be between 8 and 20 bytes in length.</param>
+        /// <returns>True if the build-id is compliant and could be resized and padded. False otherwise.</returns>
         private static bool NormalizeBuildId(ref byte[] buildId)
         {
             if (buildId == null || buildId.Length > 20 || buildId.Length < 8)

--- a/src/Microsoft.SymbolStore/KeyGenerators/ELFFileKeyGenerator.cs
+++ b/src/Microsoft.SymbolStore/KeyGenerators/ELFFileKeyGenerator.cs
@@ -196,7 +196,7 @@ namespace Microsoft.SymbolStore.KeyGenerators
         /// <returns>symbol store keys</returns>
         private static void NormalizeBuildId(ref byte[] buildId)
         {
-            if (buildId != null && buildId.Length < 20 && buildId.Length >= 16)
+            if (buildId != null && buildId.Length < 20 && buildId.Length >= 8)
             {
                 int oldLength = buildId.Length;
                 Array.Resize(ref buildId, 20);


### PR DESCRIPTION
8 byte/64 bit build ids need to be padding to 20 bytes/160 bits according to spec.