### PR TITLE
Fix a couple of arithmetic overflows

### DIFF
--- a/src/Microsoft.FileFormats/ELF/ELFFile.cs
+++ b/src/Microsoft.FileFormats/ELF/ELFFile.cs
@@ -8,7 +8,7 @@ using System.Text;
 
 namespace Microsoft.FileFormats.ELF
 {
-    public class ELFFile
+    public class ELFFile : IDisposable
     {
         private readonly ulong _position;
         private readonly bool _isDataSourceVirtualAddressSpace;
@@ -45,6 +45,14 @@ namespace Microsoft.FileFormats.ELF
         public Reader VirtualAddressReader { get { return _virtualAddressReader.Value; } }
         public byte[] BuildID { get { return _buildId.Value; } }
         public byte[] SectionNameTable { get { return _sectionNameTable.Value; } }
+
+        public void Dispose()
+        {
+            if (_reader.DataSource is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
 
         public bool IsValid()
         {

--- a/src/Microsoft.FileFormats/MachO/MachOFile.cs
+++ b/src/Microsoft.FileFormats/MachO/MachOFile.cs
@@ -1,15 +1,13 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.FileFormats;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace Microsoft.FileFormats.MachO
 {
-    public class MachOFatFile
+    public class MachOFatFile : IDisposable
     {
         private readonly Reader _reader;
         private readonly Lazy<MachFatHeaderMagic> _headerMagic;
@@ -32,6 +30,14 @@ namespace Microsoft.FileFormats.MachO
         public MachFatHeader Header { get { return _header.Value; } }
         public MachFatArch[] Arches { get { return _arches.Value; } }
         public MachOFile[] ArchSpecificFiles { get { return _archSpecificFiles.Value; } }
+
+        public void Dispose()
+        {
+            if (_reader.DataSource is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
 
         public bool IsValid()
         {
@@ -70,7 +76,7 @@ namespace Microsoft.FileFormats.MachO
         }
     }
 
-    public class MachOFile
+    public class MachOFile : IDisposable
     {
         private readonly ulong _position;
         private readonly bool _dataSourceIsVirtualAddressSpace;
@@ -113,6 +119,13 @@ namespace Microsoft.FileFormats.MachO
         public MachSymtab Symtab { get { return _symtab.Value; } }
         private Reader DataSourceReader { get { return _dataSourceReader.Value; } }
 
+        public void Dispose()
+        {
+            if (_reader.DataSource is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
         public bool IsValid()
         {
             if (_reader.Length > (_position + _reader.SizeOf<MachHeaderMagic>()))

--- a/src/Microsoft.FileFormats/PDB/PDBFile.cs
+++ b/src/Microsoft.FileFormats/PDB/PDBFile.cs
@@ -3,13 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Microsoft.FileFormats.PDB
 {
-    public class PDBFile
+    public class PDBFile : IDisposable
     {
         private readonly Reader _reader;
         private readonly Lazy<PDBFileHeader> _header;
@@ -33,6 +30,14 @@ namespace Microsoft.FileFormats.PDB
         public uint Age { get { return NameStream.Header.Age; } }
         public uint DbiAge { get { return DbiStream.Header.Age; } }
         public Guid Signature { get { return new Guid(NameStream.Header.Guid); } }
+
+        public void Dispose()
+        {
+            if (_reader.DataSource is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
 
         public bool IsValid()
         {

--- a/src/Microsoft.FileFormats/PDB/PDBFile.cs
+++ b/src/Microsoft.FileFormats/PDB/PDBFile.cs
@@ -71,7 +71,7 @@ namespace Microsoft.FileFormats.PDB
 
         private uint ToPageCount(uint size)
         {
-            return (Header.PageSize + size - 1) / Header.PageSize;
+            return unchecked((Header.PageSize + size - 1) / Header.PageSize);
         }
     }
 

--- a/src/Microsoft.FileFormats/PE/PEFile.cs
+++ b/src/Microsoft.FileFormats/PE/PEFile.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.CodeDom;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -12,7 +11,7 @@ namespace Microsoft.FileFormats.PE
     /// <summary>
     /// A very basic PE reader that can extract a few useful pieces of information
     /// </summary>
-    public class PEFile
+    public class PEFile : IDisposable
     {
         // PE file
         private readonly bool _isDataSourceVirtualAddressSpace;
@@ -79,6 +78,14 @@ namespace Microsoft.FileFormats.PE
         public VsFixedFileInfo VersionInfo { get { return _vsFixedFileInfo.Value; } }
         public IEnumerable<PEPerfMapRecord> PerfMapsV1 { get { return _perfMapsV1.Value; } }
         public IEnumerable<PdbChecksum> PdbChecksums { get { return _pdbChecksum.Value; } }
+
+        public void Dispose()
+        {
+            if (_headerReader.DataSource is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
 
         public bool IsValid()
         {
@@ -332,6 +339,7 @@ namespace Microsoft.FileFormats.PE
             {
                 numNameEntries = 0;
             }
+
             if (numIDEntries == ushort.MaxValue)
             {
                 numIDEntries = 0;

--- a/src/Microsoft.FileFormats/PE/PEFile.cs
+++ b/src/Microsoft.FileFormats/PE/PEFile.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.CodeDom;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -326,6 +327,15 @@ namespace Microsoft.FileFormats.PE
         {
             ushort numNameEntries = resourceDirectory.NumberOfNamedEntries;
             ushort numIDEntries = resourceDirectory.NumberOfIdEntries;
+
+            if (numNameEntries == ushort.MaxValue)
+            {
+                numNameEntries = 0;
+            }
+            if (numIDEntries == ushort.MaxValue)
+            {
+                numIDEntries = 0;
+            }
 
             uint directorySize = RelativeVirtualAddressReader.SizeOf<ImageResourceDirectory>();
             uint entrySize = RelativeVirtualAddressReader.SizeOf<ImageResourceDirectoryEntry>();

--- a/src/Microsoft.FileFormats/StreamAddressSpace.cs
+++ b/src/Microsoft.FileFormats/StreamAddressSpace.cs
@@ -12,8 +12,10 @@ namespace Microsoft.FileFormats
     /// <summary>
     /// Creates an address space that reads from a stream.
     /// </summary>
-    public sealed class StreamAddressSpace : IAddressSpace
+    public sealed class StreamAddressSpace : IAddressSpace, IDisposable
     {
+        private Stream _stream;
+
         public StreamAddressSpace(Stream stream)
         {
             System.Diagnostics.Debug.Assert(stream.CanSeek);
@@ -36,6 +38,10 @@ namespace Microsoft.FileFormats
         /// <returns>The number of bytes read</returns>
         public uint Read(ulong position, byte[] buffer, uint bufferOffset, uint count)
         {
+            if (_stream is null)
+            {
+                throw new ObjectDisposedException(nameof(_stream), "StreamAddressSpace instance has been disposed");
+            }
             if (position + count > Length)
             {
                 throw new BadInputFormatException("Unexpected end of data: Expected " + count + " bytes.");
@@ -44,6 +50,10 @@ namespace Microsoft.FileFormats
             return (uint)_stream.Read(buffer, (int)bufferOffset, (int)count);
         }
 
-        private Stream _stream;
+        public void Dispose()
+        {
+            _stream?.Dispose();
+            _stream = null;
+        }
     }
 }


### PR DESCRIPTION
Fix issue https://github.com/dotnet/symstore/issues/400 arithmetic overflow reading PDBs with -1 stream sizes.

Fix overflow reading resources from a PE when entry counts are -1.

Make ELFFile, MachOFile, PEFile and PDBFile IDisposable for diagnostics repo changes.