### PR TITLE
Add support for non-Basic Auth PAT tokens

### DIFF
--- a/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs
+++ b/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs
@@ -15,12 +15,6 @@ using System.Threading.Tasks;
 
 namespace Microsoft.SymbolStore.SymbolStores
 {
-    public class SymbolAuthHeader
-    {
-        public string Scheme { get; set; }
-        public string Parameter { get; set; }
-    }
-
     /// <summary>
     /// Basic http symbol store. The request can be authentication with a PAT for VSTS symbol stores.
     /// </summary>
@@ -121,16 +115,21 @@ namespace Microsoft.SymbolStore.SymbolStores
         /// <param name="backingStore">next symbol store or null</param>
         /// <param name="symbolServerUri">symbol server url</param>
         /// <param name="authenticationHeader">The header information to use for the AuthenticationHeaderValue</param>
-        public HttpSymbolStore(ITracer tracer, SymbolStore backingStore, Uri symbolServerUri, SymbolAuthHeader authenticationHeader)
+        public HttpSymbolStore(ITracer tracer, SymbolStore backingStore, Uri symbolServerUri, string scheme, string parameter)
             : this(tracer, backingStore, symbolServerUri, true)
         {
-            if (authenticationHeader == null)
+            if (string.IsNullOrEmpty(scheme))
             {
-                throw new ArgumentException(nameof(authenticationHeader));
+                throw new ArgumentException(nameof(scheme));
+            }
+
+            if (string.IsNullOrEmpty(parameter))
+            {
+                throw new ArgumentException(nameof(parameter));
             }
 
             // Create authenticated header with given SymbolAuthHeader
-            _authenticatedClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(authenticationHeader.Scheme, authenticationHeader.Parameter);
+            _authenticatedClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(scheme, parameter);
             // Force redirect logins to fail.
             _authenticatedClient.DefaultRequestHeaders.Add("X-TFS-FedAuthRedirect", "Suppress");
         }

--- a/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs
+++ b/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs
@@ -114,18 +114,19 @@ namespace Microsoft.SymbolStore.SymbolStores
         /// <param name="tracer">logger</param>
         /// <param name="backingStore">next symbol store or null</param>
         /// <param name="symbolServerUri">symbol server url</param>
-        /// <param name="authenticationHeader">The header information to use for the AuthenticationHeaderValue</param>
+        /// <param name="scheme">The scheme information to use for the AuthenticationHeaderValue</param>
+        /// <param name="parameter">The parameter information to use for the AuthenticationHeaderValue</param>
         public HttpSymbolStore(ITracer tracer, SymbolStore backingStore, Uri symbolServerUri, string scheme, string parameter)
             : this(tracer, backingStore, symbolServerUri, true)
         {
             if (string.IsNullOrEmpty(scheme))
             {
-                throw new ArgumentException(nameof(scheme));
+                throw new ArgumentNullException(nameof(scheme));
             }
 
             if (string.IsNullOrEmpty(parameter))
             {
-                throw new ArgumentException(nameof(parameter));
+                throw new ArgumentNullException(nameof(parameter));
             }
 
             // Create authenticated header with given SymbolAuthHeader


### PR DESCRIPTION
This PR adds in a new class SymbolAuthHeader which contains a scheme and parameter that will be passed into AuthenticationHeaderValue's constructor.

This will allow non-"Basic" auth headers such as "Bearer" and etc.

@gregg-miskelly @chuckries 