### PR TITLE
Fix overflow on certain ELF symbol files

### DIFF
--- a/src/Microsoft.FileFormats/ELF/ELFFile.cs
+++ b/src/Microsoft.FileFormats/ELF/ELFFile.cs
@@ -178,16 +178,22 @@ namespace Microsoft.FileFormats.ELF
 
             if (Header.ProgramHeaderOffset > 0 && Header.ProgramHeaderEntrySize > 0 && Header.ProgramHeaderCount > 0)
             {
-                foreach (ELFProgramSegment segment in Segments)
+                try
                 {
-                    if (segment.Header.Type == ELFProgramHeaderType.Note)
+                    foreach (ELFProgramSegment segment in Segments)
                     {
-                        buildId = ReadBuildIdNote(segment.Contents);
-                        if (buildId != null)
+                        if (segment.Header.Type == ELFProgramHeaderType.Note)
                         {
-                            break;
+                            buildId = ReadBuildIdNote(segment.Contents);
+                            if (buildId != null)
+                            {
+                                break;
+                            }
                         }
                     }
+                }
+                catch (Exception ex) when (ex is InvalidVirtualAddressException || ex is BadInputFormatException || ex is OverflowException)
+                {
                 }
             }
 


### PR DESCRIPTION
The problem is that the program header NOTE file offset is incorrectly the virtual offset.

This is fixed by falling back to getting the build id from the Section headers when reading the program header NOTE overflows or fails.